### PR TITLE
Index pages use scrollable windows to display main content

### DIFF
--- a/Admin/Pages/Certificates/Descriptions/Index.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Index.cshtml
@@ -1,52 +1,80 @@
 ﻿@page
 @model Admin.Pages.Certificates.Descriptions.IndexModel
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "Certificate Descriptions";
 }
 
-<h2>Certificate Descriptions</h2>
+<h1>Certificate Descriptions</h1>
 
-<p>
-    <a class="btn btn-dark" asp-page="Create">Create New</a>
-    <a class="btn btn-dark pull-right" asp-page="../Index">Certificates</a>
+<p class="space-btns">
+    <a class="btn btn-dark" asp-page="Create">Create New</a>    
+    <a class="btn btn-info pull-right" href="/Certificates/Descriptions">Certificate Descriptions</a>
+    <a class="btn btn-secondary pull-right" href="/Certificates">Certificates</a>
 </p>
+
+@{
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.Descriptions.Where(e => ((Model.Filter == null
+        || e.DescEng.ToLower().Contains(Model.Filter.ToLower())
+        || e.DescFre.ToLower().Contains(Model.Filter.ToLower()))
+        && ((e.DescFre != "" && e.DescEng != "")
+        && (e.Active == 1))));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.DescEng.ToLower()).ToList();
+}
+
 <form>
     <div class="form-actions no-color">
         <h6>
-            Find certificate descriptions:
-            <input type="text" asp-for="@Model.Filter" />
-            <input type="submit" value="Search" class="btn btn-primary" /> |
-            <a asp-page="./Index">Back to Full List</a>
+            <label for="Filter">Find certificate descriptions:</label>
+            <input type="text" asp-for="@Model.Filter" value="@filterValue" />
+            <input type="submit" value="Search" class="btn btn-primary" /> 
+            @if (!String.IsNullOrWhiteSpace(Model.Filter))
+            {
+                <span><span class="vertical-bar">|</span> <a asp-page="./Index">Back to Full List</a></span>
+            }
         </h6>
     </div>
 </form>
-<table class="table">
-    <thead>
-        <tr>
-            <th>Certificate Description English</th>
-            <th>Certificate Description French</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in Model.Descriptions.Where(e => Model.Filter == null || e.DescEng.ToLower().Contains(@Model.Filter.ToLower()) || e.DescFre.ToLower().Contains(@Model.Filter.ToLower())))
-        {
-            if (item.Active != 0) {
-            <tr>
-                <td>
-                    @Html.DisplayFor(modelItem => item.DescEng)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.DescFre)
-                </td>
-                <td style="width:15%">
-                    <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
-                    <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
-                    <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
-                </td>
-            </tr>
-            }
-        }
-    </tbody>
-</table>
 
+@if (itemsThatMatchFilter.Count() > 0)
+{
+    <div id="table-container">
+          <table class="table">
+                <thead>
+                    <tr class="table-header-row text-center">
+                        <th><b>Certificate Description English</b></th>
+                        <th><b>Certificate Description French</b></th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in itemsThatMatchFilter)
+                    {
+                        <tr>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.DescEng)
+                            </td>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.DescFre)
+                            </td>
+                            <td style="width:15%">
+                                <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
+                                <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
+                                <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+          </table>
+    </div>
+}
+else
+{
+    <h4 class="no-results">No certificate descriptions match the filter "@Model.Filter"</h4>
+}

--- a/Admin/Pages/Certificates/Index.cshtml
+++ b/Admin/Pages/Certificates/Index.cshtml
@@ -5,49 +5,76 @@
     ViewData["Title"] = "Certificates";
 }
 
-<h2>Certificates</h2>
+<h1>Certificates</h1>
 
+<p class="space-btns">
+    <a class="btn btn-dark" asp-page="Create">Create New</a>
+    <a class="btn btn-secondary pull-right" href="/Certificates/Descriptions">Certificate Descriptions</a>
+    <a class="btn btn-info pull-right" href="/Certificates">Certificates</a>
+</p>
 
-<a class="btn btn-dark" asp-page="Create">Create New</a>
-<a class="btn btn-dark pull-right" asp-page="Descriptions/Index">Descriptions</a>
+@{
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
 
+    var itemsThatMatchFilter = Model.Certificates.Where(e => (Model.Filter == null 
+        || e.NameEng.ToLower().Contains(Model.Filter.ToLower()) 
+        || e.NameFre.ToLower().Contains(Model.Filter.ToLower()))
+        && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.NameEng.ToLower()).ToList();
+}
 
 <form>
     <div class="form-actions no-color">
         <h6>
-            Find certificates:
-            <input type="text" asp-for="@Model.Filter" />
-            <input type="submit" value="Search" class="btn btn-primary" /> |
-            <a asp-page="./Index">Back to Full List</a>
+            <label for="Filter">Find certificates:</label>
+            <input type="text" asp-for="@Model.Filter" value="@filterValue" />
+            <input type="submit" value="Search" class="btn btn-primary" /> 
+            @if (!String.IsNullOrWhiteSpace(Model.Filter))
+            {
+                <span><span class="vertical-bar">|</span> <a asp-page="./Index">Back to Full List</a></span>
+            }
         </h6>
     </div>
 </form>
-<table class="table">
-    <thead>
-        <tr>
-            <th>Certificate English</th>
-            <th>Certificate French</th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in Model.Certificates.Where(e => Model.Filter == null || e.NameEng.ToLower().Contains(@Model.Filter.ToLower()) || e.NameFre.ToLower().Contains(@Model.Filter.ToLower())))
-        {
-            if (item.Active != 0) { 
-            <tr>
-                <td>
-                    @Html.DisplayFor(modelItem => item.NameEng)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.NameFre)
-                </td>
-                <td style="width:15%">
-                    <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
-                    <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
-                    <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
-                </td>
-            </tr>
-            }
-        }
-    </tbody>
-</table>
+
+@if (itemsThatMatchFilter.Count() > 0)
+{
+    <div id="table-container">
+        <table class="table">
+            <thead>
+                <tr class="table-header-row text-center">
+                    <th><b>Certificate English</b></th>
+                    <th><b>Certificate French</b></th>
+                    <th></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in itemsThatMatchFilter)
+                {
+                    <tr>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.NameEng)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.NameFre)
+                        </td>
+                        <td style="width:15%">
+                            <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
+                            <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
+                            <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+} 
+else
+{
+    <h4 class="no-results">No certificates match the filter "@Model.Filter"</h4>
+}

--- a/Admin/Pages/Competencies/List.cshtml
+++ b/Admin/Pages/Competencies/List.cshtml
@@ -1,69 +1,96 @@
 ﻿@page
 @model Admin.Pages.Competencies.ListModel
 @{
-    ViewData["Title"] = "List";
+    ViewData["Title"] = "Competencies";
+    string typeid = Model.Type.Id.ToString();
+    string classSelectedComp = "btn-info", classUnselectedComp = "btn-secondary";
 }
 
+@{
+    var filterdata = new Dictionary<string, string>
+    {
+            { "typeid", typeid },
+            {"filter", Model.Filter }
+    };
+
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.Competencies.Where(e => (Model.Filter == null
+        || e.NameEng.ToLower().Contains(@Model.Filter.ToLower())
+        || e.NameFre.ToLower().Contains(@Model.Filter.ToLower()))
+        && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.NameEng.ToLower()).ToList();
+}
 
 <h1>@Model.Type.NameEng / @Model.Type.NameFre</h1>
 
-<p>
+<p class="space-btns">
     <a class="btn btn-dark" asp-page="/Competencies/Create" asp-route-typeid="@Model.Type.Id">Create New</a>
+    <a href="@("/Competencies/List?typeid=4&filter=" + filterValue)" class="btn pull-right @(typeid == "4" ? classSelectedComp : classUnselectedComp)">Executive</a>
+    <a href="@("/Competencies/List?typeid=3&filter=" + filterValue)" class="btn pull-right @(typeid == "3" ? classSelectedComp : classUnselectedComp)">Behavioural</a>
+    <a href="@("/Competencies/List?typeid=2&filter=" + filterValue)" class="btn pull-right @(typeid == "2" ? classSelectedComp : classUnselectedComp)">Technical</a>
+    <a href="@("/Competencies/List?typeid=1&filter=" + filterValue)" class="btn pull-right @(typeid == "1" ? classSelectedComp : classUnselectedComp)">Knowledge</a>
 </p>
-@{ 
-            var filterdata = new Dictionary<string, string>
-    {
-            { "typeid", Model.Type.Id.ToString() },
-            {"filter", Model.Filter }
-    };
-}
 <form method="post">
     <div class="form-actions no-color">
         <h6>
-            Find competencies:
+            <label for="Filter">Find competencies:</label>
             <input type="text" asp-for="@Model.Filter"/>
-            <input type="submit" value="Search" class="btn btn-primary" asp-all-route-data="@filterdata" /> |
-            <a asp-page="./List" asp-route-typeid="@Model.Type.Id">Back to Full List</a>
+            <input type="submit" value="Search" class="btn btn-primary" asp-all-route-data="@filterdata" /> 
+            @if (!String.IsNullOrWhiteSpace(Model.Filter))
+            {
+                <span><span class="vertical-bar">|</span> <a href="/Competencies/List?typeid=@typeid">Back to Full List</a></span>
+            }
         </h6>
     </div>
 </form>
 
-<hr />
-
-<table class="table">
-    <thead>
-        <tr>
-            <th><b>Competency English</b></th>
-            <th><b>Competency French</b></th>
-            <th><b>Description English</b></th>
-            <th><b>Description French</b></th>
-            <th></th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in Model.Competencies.Where(e => Model.Filter == null || e.NameEng.ToLower().Contains(@Model.Filter.ToLower()) || e.NameFre.ToLower().Contains(@Model.Filter.ToLower())))
-        {
-            if (item.Active != 0) {
-            <tr>
-                <td>
-                    @Html.DisplayFor(modelItem => item.NameEng)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.NameFre)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.DescEng)
-                </td>
-                <td>
-                    @Html.DisplayFor(modelItem => item.DescFre)
-                </td>
-                <td>
-                    <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
-                    <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
-                    <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
-                </td>
-            </tr>
-            }
-        }
-    </tbody>
-</table>
+@if (itemsThatMatchFilter.Count() > 0)
+{
+    <div id="table-container">
+        <table class="table">
+            <thead>
+                <tr class="table-header-row text-center">
+                    <th class="col-2"><b>Competency English</b></th>
+                    <th class="col-2"><b>Competency French</b></th>
+                    <th class="col-3"><b>Description English</b></th>
+                    <th class="col-4"><b>Description French</b></th>
+                    <th class="col-1"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in itemsThatMatchFilter)
+                {
+                    <tr>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.NameEng)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.NameFre)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.DescEng)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.DescFre)
+                        </td>
+                        <td class="text-center">
+                            <a asp-page="./Details" asp-route-id="@item.Id">Details</a>
+                            <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a>
+                            <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                        </td>
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <h4 class="no-results">No @Model.Type.NameEng.ToLower() match the filter "@Model.Filter"</h4>
+}

--- a/Admin/Pages/Competencies/List.cshtml.cs
+++ b/Admin/Pages/Competencies/List.cshtml.cs
@@ -15,7 +15,6 @@ namespace Admin.Pages.Competencies
     {
         private readonly DataModel.CctDbContext _context;
         private readonly JobCompetencyService _jobCompetencyService;
-        private static readonly int[] AccepetedTypeIds = { 1, 2, 3, 4 };
 
         public ListModel(DataModel.CctDbContext context, JobCompetencyService jobCompetencyService)
         {
@@ -29,7 +28,9 @@ namespace Admin.Pages.Competencies
 
         public async Task OnGetAsync(int typeId)
         {
-            if (!AccepetedTypeIds.Contains(typeId))
+            var accepetedTypeIds = _context.CompetencyTypes.Select(c => c.Id).ToList();
+
+            if (!accepetedTypeIds.Contains(typeId))
             {
                 Type = await _jobCompetencyService.GetJobCompetencyTypeById(1);
                 Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
@@ -39,18 +40,6 @@ namespace Admin.Pages.Competencies
                 Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(typeId);
             }
         }
-        public async Task OnPostAsync(int typeId)
-        {
-            if (typeId == 0 && !string.IsNullOrEmpty(Filter))
-            {
-                Type = await _jobCompetencyService.GetJobCompetencyTypeById(1);
-                Competencies = await _jobCompetencyService.GetAllJobCompetencies();
-            }
-            else
-            {
-                Type = await _jobCompetencyService.GetJobCompetencyTypeById(typeId);
-                Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(typeId);
-            }
-        }
+
     }
 }

--- a/Admin/Pages/Competencies/List.cshtml.cs
+++ b/Admin/Pages/Competencies/List.cshtml.cs
@@ -15,6 +15,7 @@ namespace Admin.Pages.Competencies
     {
         private readonly DataModel.CctDbContext _context;
         private readonly JobCompetencyService _jobCompetencyService;
+        private static readonly int[] AccepetedTypeIds = { 1, 2, 3, 4 };
 
         public ListModel(DataModel.CctDbContext context, JobCompetencyService jobCompetencyService)
         {
@@ -28,14 +29,14 @@ namespace Admin.Pages.Competencies
 
         public async Task OnGetAsync(int typeId)
         {
-            if (typeId == 0 && !string.IsNullOrEmpty(Filter))
+            if (!AccepetedTypeIds.Contains(typeId))
             {
                 Type = await _jobCompetencyService.GetJobCompetencyTypeById(1);
-                Competencies = await _jobCompetencyService.GetAllJobCompetencies();
+                Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
             }
             else { 
-            Type = await _jobCompetencyService.GetJobCompetencyTypeById(typeId);
-            Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(typeId);
+                Type = await _jobCompetencyService.GetJobCompetencyTypeById(typeId);
+                Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(typeId);
             }
         }
         public async Task OnPostAsync(int typeId)

--- a/Admin/Pages/Positions/Index.cshtml
+++ b/Admin/Pages/Positions/Index.cshtml
@@ -8,35 +8,54 @@
 <p>
     <a class="btn btn-dark" asp-page="Create">Create New</a>
 </p>
+
+@{
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.JobPositions.Where(e => (Model.Filter == null
+        || e.JobTitleEng.ToLower().Contains(Model.Filter.ToLower())
+        || e.JobTitleFre.ToLower().Contains(Model.Filter.ToLower())
+        || e.LevelCode.ToLower().Contains(Model.Filter.ToLower()))
+        && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+}
+
 <form>
     <div class="form-actions no-color">
         <h6>
-            Find similar positions:
-            <input type="text" asp-for="@Model.Filter" />
-            <input type="submit" value="Search" class="btn btn-primary" /> |
-            <a asp-page="./Index">Back to Full List</a>
+            <label for="Filter">Find positions:</label>
+            <input type="text" asp-for="@Model.Filter" value="@filterValue" />
+            <input type="submit" value="Search" class="btn btn-primary" /> 
+            @if (!String.IsNullOrWhiteSpace(Model.Filter))
+            {
+                <span><span class="vertical-bar">|</span> <a asp-page="./Index">Back to Full List</a></span>
+            }
         </h6>
     </div>
 </form>
 
-<table class="table">
-    <thead>
-        <tr>
-            <th width="7%"><b>Level</b></th>
-            <th width="35%"><b>Title English</b></th>
-            <th width="35%"><b>Title French</b></th>
-            <th width="15%"></th>
-        </tr>
-    </thead>
-    <tbody>
-        @if (Model.JobPositions.Any(e => Model.Filter == null || e.JobTitleEng.ToLower().Contains(@Model.Filter.ToLower()) || e.JobTitleFre.ToLower().Contains(@Model.Filter.ToLower()) || e.LevelCode.ToLower().Contains(@Model.Filter.ToLower())))
-        {
-            @foreach (var item in Model.JobPositions.Where(e => Model.Filter == null || e.JobTitleEng.ToLower().Contains(@Model.Filter.ToLower()) || e.JobTitleFre.ToLower().Contains(@Model.Filter.ToLower())))
-            {
-                if (item.Active != 0)
+@if (itemsThatMatchFilter.Count() > 0)
+{
+    <div id="table-container">
+        <table class="table">
+            <thead>
+                <tr class="table-header-row text-center">
+                    <th width="7%"><b>Level</b></th>
+                    <th width="35%"><b>Title English</b></th>
+                    <th width="35%"><b>Title French</b></th>
+                    <th width="15%"></th>
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in itemsThatMatchFilter)
                 {
                     <tr>
-                        <td>
+                        <td class="text-center">
                             @Html.DisplayFor(modelItem => item.LevelCode)
                         </td>
                         <td>
@@ -52,7 +71,11 @@
                         </td>
                     </tr>
                 }
-            }
-        }
-    </tbody>
-</table>
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <h4 class="no-results">No positions match the filter "@Model.Filter"</h4>
+}

--- a/Admin/Pages/Similar/Index.cshtml
+++ b/Admin/Pages/Similar/Index.cshtml
@@ -1,60 +1,120 @@
 ﻿@page
 @model Admin.Pages.Similar.IndexModel
 @{
-    ViewData["Title"] = "Index";
+    ViewData["Title"] = "Similar Positions";
 }
 
 <h1>Similar Positions</h1>
 
+@{
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.JobPositions.Where(e => (Model.Filter == null
+        || e.JobTitleEng.ToLower().Contains(Model.Filter.ToLower())
+        || e.JobTitleFre.ToLower().Contains(Model.Filter.ToLower())
+        || e.LevelCode.ToLower().Contains(Model.Filter.ToLower()))
+        && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+}
+
 <form>
     <div class="form-actions no-color">
         <h6>
-            Find similar positions:
+            <label for="Filter">Find positions:</label>
             <input type="text" asp-for="@Model.Filter" />
-            <input type="submit" value="Search" class="btn btn-primary" /> |
-            <a asp-page="./Index">Back to Full List</a>
-        </h6>
-    </div>
-</form>
-<table class="table">
-    <thead>
-        <tr>
-            <th width="7%"><b>Level</b></th>
-            <th width="35%"><b>Title English</b></th>
-            <th width="35%"><b>Title French</b></th>
-            <th width="15%"></th>
-        </tr>
-    </thead>
-    <tbody>
-        @foreach (var item in Model.JobPositions.Where(e => Model.Filter == null || e.JobTitleEng.ToLower().Contains(@Model.Filter.ToLower()) || e.JobTitleFre.ToLower().Contains(@Model.Filter.ToLower()) || e.LevelCode.ToLower().Contains(@Model.Filter.ToLower())))
-        {
-            if (item.Active != 0) {
-        <tr>
-            <td>
-                @Html.DisplayFor(modelItem => item.LevelCode)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.JobTitleEng)
-            </td>
-            <td>
-                @Html.DisplayFor(modelItem => item.JobTitleFre)
-            </td>
-            @if (Model.SimilarSearchIds.Contains(item.JobTitleId))
+            <input type="submit" value="Search" class="btn btn-primary" /> 
+            @if (!String.IsNullOrWhiteSpace(Model.Filter))
             {
-                <td>
-                    <a asp-page="./Details" asp-route-id="@item.JobTitleId">Details</a> |
-                    <a asp-page="./Edit" asp-route-id="@item.JobTitleId">Edit</a>
-                </td>
+                <span><span class="vertical-bar">|</span> <a href="/Similar@(Model.DisplayNumberOfJobsForEachMatchingPercentage ? "?numMatching=true" : "")">
+                    Back to Full List</a></span>
+            }
+            @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
+            {
+                <a class="pull-right" href="/Similar?filter=@filterValue">Hide Number of Matching Positions Per Percentage</a>
             }
             else
             {
-                <td>
-                    <a asp-page="./Create" asp-route-id="@item.JobTitleId">Create</a>
-                </td>
+                <a class="pull-right" href="/Similar?numMatching=true&filter=@filterValue">View Number of Matching Positions Per Percentage</a>
             }
-        </tr>
-            }
-        }
-    </tbody>
-</table>
+        </h6>
+    </div>
+</form>
+
+@if (itemsThatMatchFilter.Count() > 0)
+{
+    <div id="table-container">
+        <table class="table">
+            <thead>
+                <tr class="table-header-row text-center">
+                    @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
+                    {
+                        <th class="col-1"><b>Level</b></th>
+                        <th class="col-3"><b>Title English</b></th>
+                        <th class="col-3"><b>Title French</b></th>
+                        <th class="col-3"><div class="four-col-grid"><span>100%</span><span>90%</span>
+                            <span>80%</span><span>70%</span></div></th>
+                        <th class="col-2"></th>
+                    }
+                    else
+                    {
+                        <th class="col-1"><b>Level</b></th>
+                        <th class="col-4"><b>Title English</b></th>
+                        <th class="col-5"><b>Title French</b></th>
+                        <th class="col-2"></th>
+                    }
+                </tr>
+            </thead>
+            <tbody>
+                @foreach (var item in itemsThatMatchFilter)
+                {
+                    <tr>
+                        <td class="text-center">
+                            @Html.DisplayFor(modelItem => item.LevelCode)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.JobTitleEng)
+                        </td>
+                        <td>
+                            @Html.DisplayFor(modelItem => item.JobTitleFre)
+                        </td>
+                        @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
+                        {
+                            <td class="four-col-grid">
+                                @{
+                                    foreach (var positionCount in 
+                                                Model.NumberOfMatchingPositionsPerPecrentagePerPosition[item.JobTitleId].Split("&"))
+                                    {
+                                        <span>@positionCount</span>
+                                    }
+                                }
+                            </td>
+                        }
+                        @if (Model.SimilarSearchIds.Contains(item.JobTitleId))
+                        {
+                            <td class="text-center">
+                                <a asp-page="./Details" asp-route-id="@item.JobTitleId">Details</a> |
+                                <a asp-page="./Edit" asp-route-id="@item.JobTitleId">Edit</a>
+                            </td>
+                        }
+                        else
+                        {
+                            <td class="text-center">
+                                <a asp-page="./Create" asp-route-id="@item.JobTitleId">Create</a>
+                            </td>
+                        }
+                    </tr>
+                }
+            </tbody>
+        </table>
+    </div>
+}
+else
+{
+    <h4 class="no-results">No positions match the filter "@Model.Filter"</h4>
+}
 

--- a/Admin/Pages/Similar/Index.cshtml.cs
+++ b/Admin/Pages/Similar/Index.cshtml.cs
@@ -4,6 +4,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Admin.Data;
 using Business.Dtos.JobPositions;
 using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using DataModel;
 
 namespace Admin.Pages.Similar
 {
@@ -23,10 +26,104 @@ namespace Admin.Pages.Similar
         public IList<JobPositionDto> JobPositions { get; set; }
         public int[] SimilarSearchIds { get; set; }
 
-        public async Task OnGetAsync()
+        [BindProperty]
+        public SearchSimilarJob JobPosition { get; set; }
+
+        public bool DisplayNumberOfJobsForEachMatchingPercentage { get; set; } = false;
+
+        public Dictionary<int, string> NumberOfMatchingPositionsPerPecrentagePerPosition { get; set; }
+
+        public async Task OnGetAsync(string? numMatching)
         {
             JobPositions = await _jobPositionService.GetAllJobPositions();
+            JobPositions = JobPositions.Where(x => x.Active == 1).ToList();
             SimilarSearchIds = await _jobPositionService.GetAllSimilarSearchIds();
-        }
-    }
-}
+            NumberOfMatchingPositionsPerPecrentagePerPosition = new Dictionary<int, string>();
+
+            if (numMatching != null)
+            {
+                if (numMatching.ToLower() == "true")
+                {
+                    DisplayNumberOfJobsForEachMatchingPercentage = true;
+                }
+            }
+
+            if (DisplayNumberOfJobsForEachMatchingPercentage)
+            {
+                Dictionary<int, bool> activeJobIds = new Dictionary<int, bool>();
+                bool boolVar;
+
+                foreach (var position in JobPositions)
+                {
+                    activeJobIds.Add(position.JobTitleId, true);
+                }
+
+                foreach (var position in JobPositions)
+                {
+                    JobPosition = await _context.SearchSimilarJobs.FirstOrDefaultAsync(m => m.Position == position.JobTitleId);
+                    try
+                    {
+                        int numHundredPositions = 0;
+                        var hundredPositions = JobPosition.HundredPercent.Split("&PositionId=");
+                        foreach (var pos in hundredPositions)
+                        {
+                            if (!string.IsNullOrWhiteSpace(pos))
+                            {
+                                if (activeJobIds.TryGetValue(int.Parse(pos), out boolVar))
+                                {
+                                    numHundredPositions++;
+                                }
+                            }
+                        }
+
+                        int numNinetyPositions = 0;
+                        var ninetyPositions = JobPosition.NinetyPercent.Split("&PositionId=");
+                        foreach (var pos in ninetyPositions)
+                        {
+                            if (!string.IsNullOrWhiteSpace(pos))
+                            {
+                                if (activeJobIds.TryGetValue(int.Parse(pos), out boolVar))
+                                {
+                                    numNinetyPositions++;
+                                }
+                            }
+                        }
+
+                        int numEightyPositions = 0;
+                        var eightyPositions = JobPosition.EightyPercent.Split("&PositionId=");
+                        foreach (var pos in eightyPositions)
+                        {
+                            if (!string.IsNullOrWhiteSpace(pos))
+                            {
+                                if (activeJobIds.TryGetValue(int.Parse(pos), out boolVar))
+                                {
+                                    numEightyPositions++;
+                                }
+                            }
+                        }
+
+                        int numSeventyPositions = 0;
+                        var seventyPositions = JobPosition.SeventyPercent.Split("&PositionId=");
+                        foreach (var pos in seventyPositions)
+                        {
+                            if (!string.IsNullOrWhiteSpace(pos))
+                            {
+                                if (activeJobIds.TryGetValue(int.Parse(pos), out boolVar))
+                                {
+                                    numSeventyPositions++;
+                                }
+                            }
+                        }
+
+                        NumberOfMatchingPositionsPerPecrentagePerPosition.Add(position.JobTitleId, numHundredPositions.ToString() +
+                            "&" + numNinetyPositions + "&" + numEightyPositions + "&" + numSeventyPositions);
+                    }
+                    catch
+                    {
+                        NumberOfMatchingPositionsPerPecrentagePerPosition.Add(position.JobTitleId, "-&-&-&-");
+                    }
+                } // foreach
+            } // if
+        } // OnGetAsync()
+    } // IndexModel class
+} // namespace

--- a/Admin/Pages/Similar/Index.cshtml.cs
+++ b/Admin/Pages/Similar/Index.cshtml.cs
@@ -122,8 +122,9 @@ namespace Admin.Pages.Similar
                     {
                         NumberOfMatchingPositionsPerPecrentagePerPosition.Add(position.JobTitleId, "-&-&-&-");
                     }
-                } // foreach
-            } // if
-        } // OnGetAsync()
-    } // IndexModel class
-} // namespace
+                }
+            }
+        }
+
+    }
+}

--- a/Admin/wwwroot/js/site.js
+++ b/Admin/wwwroot/js/site.js
@@ -15,15 +15,15 @@ const MARGIN_BETWEEN_FOOTER_AND_TABLE = 30;
 function qsa(selector, parent = document) {
     if ((!selector) || (!parent)) {
         return [];
-    } // if
+    } 
     let result = parent.querySelectorAll(selector);
     let nodeResults = [];
     for (let i = 0; i < result.length; i++) {
         let currentNode = /** @type {HTMLElement} */ (result[i]);
         nodeResults[i] = currentNode;
-    } // for
+    } 
     return nodeResults;
-} // qsa()
+} 
 
 /**
  * 
@@ -36,9 +36,9 @@ function qsa(selector, parent = document) {
 function qs(selector, parent = document) {
     if ((!selector) || (!parent)) {
         return null;
-    } // if
+    } 
     return /** @type {HTMLElement} */ (parent.querySelector(selector));
-} // qs()
+} 
 
 /**
  * This function is used on basically all Index pages, where there is a long list of elements to display. It handles setting the height of the element which contains the table and that can be scrolled through to make sure it takes up as much height as it can on screen without hiding anything. The minimum height for it is 300px.
@@ -52,10 +52,10 @@ function setTableContainerMaxHeight() {
         let newHeight = windowHeight - footer.getBoundingClientRect().height - tableContainer.getBoundingClientRect().y - MARGIN_BETWEEN_FOOTER_AND_TABLE;
         if (newHeight < 300) {
             newHeight = 300;
-        } // if
+        } 
         tableContainer.style.maxHeight = `${newHeight}px`;
-    } // if
-} // setTableContainerMaxHeight()
+    } 
+} 
 
 /**
  * Actions in forms which will cause the same page to be displayed can cause this function to be called which temporarily stores the current scroll offset of the window, which be applied once the page reloads (look at the checkIfWindowShouldBeScrolled() function). In order for the page scroll to be stored, the HTML element which causes the page to be reloaded (for example, the button to save changes after adding a competency in the add/edit position page) must have the css class of "resetWindowHeight".
@@ -63,7 +63,7 @@ function setTableContainerMaxHeight() {
 function storeCurrentScrollPosition() {
     let scrollValue = window.scrollY;
     localStorage.setItem(localStorageScrollStr, scrollValue.toString());
-} // storeCurrentScrollPosition()
+} 
 
 /**
  * This function gets called whenever a page loads, and simply checks localStorage to see if a window scroll offset it set there (which can be set by the storeCurrentScrollPosition() function). If there is, it will apply this offset to the window, bringing you back to the same scroll position you had before reloading the page (useful in certain forms)
@@ -76,10 +76,10 @@ function checkIfWindowShouldBeScrolled() {
             let numScroll = Number(scrollValue);
             if (!isNaN(numScroll)) {
                 window.scrollTo(window.scrollX, numScroll);
-            } // if
-        } // if
-    } // if
-} // checkIfWindowShouldBeScrolled()
+            } 
+        } 
+    } 
+} 
 
 /**
  * This function makes it so whenever you click on the "All Regions" checkbox on the add/edit position page, all other region checkboxes' state will match the one of the "All Regions" one. This allows you to click once to select all regions at once (and unselect them all at once as well).
@@ -91,9 +91,9 @@ function toggleRegionCheckboxes() {
     if (allRegionsCheckbox && otherCheckboxes) {
         for (let i = 0; i < otherCheckboxes.length; i++) {
             (/** @type {HTMLInputElement} */ (otherCheckboxes[i])).checked = allRegionsCheckbox.checked;
-        } // for
-    } // if
-} // toggleRegionCheckboxes()
+        } 
+    } 
+} 
 
 /**
  * 
@@ -106,10 +106,10 @@ function toggleRegionCheckboxes() {
 function findNearestParentOfType(el, parentTagName) {
     if ((!el) || (!parentTagName)) {
         return null;
-    } // if
+    } 
     if ((!el.parentElement)) {
         return null;
-    } // if
+    } 
 
     parentTagName = parentTagName.toLowerCase();
     let reachedRootNode = false;
@@ -117,17 +117,17 @@ function findNearestParentOfType(el, parentTagName) {
     while (el.tagName.toLowerCase() !== parentTagName && !reachedRootNode) {
         if (el.tagName.toLowerCase() === "html" || (!el.parentElement)) {
             reachedRootNode = true;
-        } // if
+        } 
         else {
             el = el.parentElement;
-        } // else
-    } // while
+        } 
+    } 
 
     if (!reachedRootNode) {
         return /** @type {HTMLElement} */ (el);
-    } // if
+    } 
     return null;
-} // findNearestParentOfType()
+} 
 
 /**
  * 
@@ -151,8 +151,8 @@ function toggleExpandableElementsInNextRows(el) {
             let currentRow = allTableRows[i];
             if (currentRow.contains(el)) {
                 startingRowIndex = i;
-            } // if
-        } // for
+            } 
+        } 
 
         for (let i = startingRowIndex + 1; i < allTableRows.length && endingRowIndex === -1; i++) {
             let currentRow = allTableRows[i];
@@ -160,12 +160,12 @@ function toggleExpandableElementsInNextRows(el) {
             for (let j = 0; j < nodesInRow.length; j++) {
                 if (nodesInRow[j].tagName.toLowerCase() === "th") {
                     endingRowIndex = i;
-                } // if
-            } // for
+                } 
+            } 
             if (i === allTableRows.length - 1 && endingRowIndex === -1) {
                 endingRowIndex = allTableRows.length;
-            } // if
-        } // for
+            } 
+        } 
 
         rowsToExpand = allTableRows.slice(startingRowIndex + 1, endingRowIndex);
 
@@ -175,22 +175,22 @@ function toggleExpandableElementsInNextRows(el) {
     
                 if (el.classList.contains("second-column")) { // this is for the competency rows/tables, where you can expand both the competency names or the levels associated to them
                     columnAffected = 2;
-                } // if
+                } 
     
                 let expandingItems = el.classList.contains("closed");
                 if (expandingItems) {
                     el.classList.remove("closed");
                     el.classList.add("opened");
-                } // if
+                } 
                 else {
                     el.classList.add("closed");
                     el.classList.remove("opened");
-                } // else
+                } 
 
                 // in the case of the add/edit position page, all expandable elements will be within the same table row. However, each item will be within a separate div.row. So, if we only have one row, and that row has at least one div.row, instead of looping through multiple table rows, we will now loop through those div.row. The rest of the code behaves the same
                 if (qsa("td div.row", rowsToExpand[0]).length > 0 && rowsToExpand.length === 1) {
                     rowsToExpand = qsa("td div.row", rowsToExpand[0]);
-                } // if
+                } 
     
                 for (let i = 0; i < rowsToExpand.length; i++) {
                     let btnsInRow = qsa("button.btn", rowsToExpand[i]);
@@ -199,13 +199,13 @@ function toggleExpandableElementsInNextRows(el) {
                         if ((i + 1) === columnAffected) {
                             if ((expandingItems && btnsInRow[i].getAttribute("aria-expanded") === "false") || (!expandingItems && btnsInRow[i].getAttribute("aria-expanded") === "true"))
                             btnsInRow[i].click();
-                        } // if
-                    } // for
-                } // for
-            } // if
-        } // if
-    } // if
-} // toggleExpandableElementsInNextRows()
+                        } 
+                    } 
+                } 
+            } 
+        } 
+    } 
+} 
 
 /**
  * 
@@ -227,11 +227,11 @@ function checkCompetencyLevelButtonsState(dropdown) {
 
     if (currentValue === minValue) {
         minusButton.classList.add("disabled");
-    } // if
+    } 
     if (currentValue === maxValue) {
         plusButton.classList.add("disabled");
-    } // if
-} // checkCompetencyLevelButtonsState()
+    } 
+} 
 
 /**
  * 
@@ -247,11 +247,11 @@ function getMaximumOrMinimumValueFromDropdown(dropdown, maximum = true) {
         let dropdownValues = [];
         for (let i = 0; i < dropdownOptions.length; i++) {
             dropdownValues[i] = /** @type {Number} */ ((/** @type {HTMLInputElement} */ (dropdownOptions[i])).value);
-        } // for
+        } 
         return maximum ? Math.max(...dropdownValues) : Math.min(...dropdownValues);
-    } // if
+    } 
     return null;
-} // getMaximumValueFromDropdown()
+} 
 
 /**
  * 
@@ -269,17 +269,17 @@ function changeCompetencyLevelValue(el, newNum = null) {
         valueChanged = true;
         newDropdownValue = newNum;
         dropdown = el;
-    } // if
+    } 
     else {
         let increment = true;
     
         if (el.classList.contains("minus-icon")) {
             dropdown = el.nextElementSibling;
             increment = false;
-        } // if
+        } 
         else {
             dropdown = el.previousElementSibling;
-        } // else
+        } 
         dropdown = /** @type {HTMLInputElement} */ (dropdown);
     
         let originalDropdownValue = Number(dropdown.value);
@@ -288,14 +288,14 @@ function changeCompetencyLevelValue(el, newNum = null) {
 
         if (increment && originalDropdownValue < maxDropdownValue) {
             dropdown.value = originalDropdownValue + 1;
-        } // if
+        } 
         if (!increment && originalDropdownValue > minDropdownValue) {
             dropdown.value = originalDropdownValue - 1;
-        } // if
+        } 
 
         newDropdownValue = Number(dropdown.value);
         valueChanged = (originalDropdownValue !== newDropdownValue);
-    } // else
+    } 
 
     if (valueChanged) {
         checkCompetencyLevelButtonsState(dropdown);
@@ -318,7 +318,7 @@ function changeCompetencyLevelValue(el, newNum = null) {
             case "exec":
                 fullCompetencyStr = "addedexecutivecompetencyids";
                 break;
-        } // switch
+        } 
         fullCompetencyStr = /** @type {String} */ (fullCompetencyStr);
 
         for (let i = 0; i < formActionElements.length; i++) {
@@ -341,9 +341,9 @@ function changeCompetencyLevelValue(el, newNum = null) {
             let updatedFormActionStr = formActionStrArr.join('');
     
             formActionElement.setAttribute("formaction", updatedFormActionStr);
-        } // for
-    } // if
-} // changeCompetencyLevelValue()
+        } 
+    } 
+} 
 
 /**
  * 
@@ -359,10 +359,10 @@ function changeCompetencyLevelValue(el, newNum = null) {
             if (target.classList.contains("changeCompetencyLevelDropdown")) {
                 changeCompetencyLevelValue(target, target.value);
                 return;
-            } // if
-        } // if
-    } // if
-} // handleChange()
+            } 
+        } 
+    } 
+} 
 
 /**
  * 
@@ -378,24 +378,24 @@ function changeCompetencyLevelValue(el, newNum = null) {
             if (target.classList.contains("resetWindowHeight")) {
                 storeCurrentScrollPosition();
                 return;
-            } // if
+            } 
             if (target.classList.contains("expand-elements-in-next-rows")) {
                 toggleExpandableElementsInNextRows(target);
                 return;
-            } // if
+            } 
             if (target.classList.contains("plus-minus-icon")) {
                 changeCompetencyLevelValue(target);
                 return;
-            } // if
-        } // if
+            } 
+        } 
         if (target.id) {
             if (target.id === "allRegionsCheckbox") {
                 toggleRegionCheckboxes();
                 return;
-            } // if
-        } // if
-    } // if
-} // handleClick()
+            } 
+        } 
+    } 
+} 
 
 // Page setup when it has loaded. Adds the appropriate event listeners and such
 window.addEventListener("load", () => {
@@ -417,5 +417,5 @@ window.addEventListener("load", () => {
             windowHeight = window.innerHeight;
             setTableContainerMaxHeight();
         });
-    } // if
+    } 
 });

--- a/Admin/wwwroot/js/site.js
+++ b/Admin/wwwroot/js/site.js
@@ -1,4 +1,421 @@
-﻿// Please see documentation at https://docs.microsoft.com/aspnet/core/client-side/bundling-and-minification
-// for details on configuring this project to bundle and minify static web assets.
+﻿let windowHeight;
+let tableContainer;
+let footer;
+let localStorageScrollStr = "CCG_CCT_WindowScroll";
+const MARGIN_BETWEEN_FOOTER_AND_TABLE = 30;
 
-// Write your Javascript code.
+/**
+ * 
+ * @param {string} selector - The string which represents the desired selection
+ * @param {Element} parent - Optional: the parent on which the selection is made (default is document)
+ * @returns - HTMLElement[]
+ * 
+ * The same querySelectorAll function that you know, expect this one returns an array of HTMLElements, and you don't call it on anything, you can simply pass an optional parent parameter to it. Returns an empty array in case no elements match.
+ */
+function qsa(selector, parent = document) {
+    if ((!selector) || (!parent)) {
+        return [];
+    } // if
+    let result = parent.querySelectorAll(selector);
+    let nodeResults = [];
+    for (let i = 0; i < result.length; i++) {
+        let currentNode = /** @type {HTMLElement} */ (result[i]);
+        nodeResults[i] = currentNode;
+    } // for
+    return nodeResults;
+} // qsa()
+
+/**
+ * 
+ * @param {string} selector - The string which represents the desired selection
+ * @param {Element} parent - Optional: the parent on which the selection is made (default is document)
+ * @returns - HTMLElement
+ * 
+ * The same querySelector function that you know, expect this one returns a HTMLElement, and you don't call it on anything, you can simply pass an optional parent parameter to it.
+ */
+function qs(selector, parent = document) {
+    if ((!selector) || (!parent)) {
+        return null;
+    } // if
+    return /** @type {HTMLElement} */ (parent.querySelector(selector));
+} // qs()
+
+/**
+ * This function is used on basically all Index pages, where there is a long list of elements to display. It handles setting the height of the element which contains the table and that can be scrolled through to make sure it takes up as much height as it can on screen without hiding anything. The minimum height for it is 300px.
+ */
+function setTableContainerMaxHeight() {
+    footer = /** @type {HTMLElement} */ (footer);
+    tableContainer = /** @type {HTMLElement} */ (tableContainer);
+    windowHeight = /** @type {number} */ (windowHeight);
+
+    if (tableContainer) {
+        let newHeight = windowHeight - footer.getBoundingClientRect().height - tableContainer.getBoundingClientRect().y - MARGIN_BETWEEN_FOOTER_AND_TABLE;
+        if (newHeight < 300) {
+            newHeight = 300;
+        } // if
+        tableContainer.style.maxHeight = `${newHeight}px`;
+    } // if
+} // setTableContainerMaxHeight()
+
+/**
+ * Actions in forms which will cause the same page to be displayed can cause this function to be called which temporarily stores the current scroll offset of the window, which be applied once the page reloads (look at the checkIfWindowShouldBeScrolled() function). In order for the page scroll to be stored, the HTML element which causes the page to be reloaded (for example, the button to save changes after adding a competency in the add/edit position page) must have the css class of "resetWindowHeight".
+ */
+function storeCurrentScrollPosition() {
+    let scrollValue = window.scrollY;
+    localStorage.setItem(localStorageScrollStr, scrollValue.toString());
+} // storeCurrentScrollPosition()
+
+/**
+ * This function gets called whenever a page loads, and simply checks localStorage to see if a window scroll offset it set there (which can be set by the storeCurrentScrollPosition() function). If there is, it will apply this offset to the window, bringing you back to the same scroll position you had before reloading the page (useful in certain forms)
+ */
+function checkIfWindowShouldBeScrolled() {
+    let scrollValue = localStorage.getItem(localStorageScrollStr);
+    if (scrollValue) {
+        localStorage.removeItem(localStorageScrollStr);
+        if (qs(".resetWindowHeight")) {
+            let numScroll = Number(scrollValue);
+            if (!isNaN(numScroll)) {
+                window.scrollTo(window.scrollX, numScroll);
+            } // if
+        } // if
+    } // if
+} // checkIfWindowShouldBeScrolled()
+
+/**
+ * This function makes it so whenever you click on the "All Regions" checkbox on the add/edit position page, all other region checkboxes' state will match the one of the "All Regions" one. This allows you to click once to select all regions at once (and unselect them all at once as well).
+ */
+function toggleRegionCheckboxes() {
+    let allRegionsCheckbox = /** @type {HTMLInputElement} */ (qs("#allRegionsCheckbox"));
+    let otherCheckboxes = qsa(`[name="SelectedRegionIds"]`);
+
+    if (allRegionsCheckbox && otherCheckboxes) {
+        for (let i = 0; i < otherCheckboxes.length; i++) {
+            (/** @type {HTMLInputElement} */ (otherCheckboxes[i])).checked = allRegionsCheckbox.checked;
+        } // for
+    } // if
+} // toggleRegionCheckboxes()
+
+/**
+ * 
+ * @param {Element} el - The child element
+ * @param {string} parentTagName - The tag name of the parent desired, for exmaple "div"
+ * @returns - HTMLElement
+ * 
+ * This function is meant to help find the nearest parent of an element of a certain type. It is limited to the tag name, meaning you can't use the full querySelector options. If no parent can be found, null will be returned.
+ */
+function findNearestParentOfType(el, parentTagName) {
+    if ((!el) || (!parentTagName)) {
+        return null;
+    } // if
+    if ((!el.parentElement)) {
+        return null;
+    } // if
+
+    parentTagName = parentTagName.toLowerCase();
+    let reachedRootNode = false;
+
+    while (el.tagName.toLowerCase() !== parentTagName && !reachedRootNode) {
+        if (el.tagName.toLowerCase() === "html" || (!el.parentElement)) {
+            reachedRootNode = true;
+        } // if
+        else {
+            el = el.parentElement;
+        } // else
+    } // while
+
+    if (!reachedRootNode) {
+        return /** @type {HTMLElement} */ (el);
+    } // if
+    return null;
+} // findNearestParentOfType()
+
+/**
+ * 
+ * @param {Element} el - The element whose siblings contained in the next table rows are to be expanded (usually a table header)
+ * 
+ * This function is used on tables headers where the elements in the next rows are expandable, for instance in the add/edit/details position page, where you can expand competencies and certificates. This function toggles every expandable element in that table, or in the case of the details page, where there are multiple subsections to the same large table, it expands every element until it meets the next "header" row of the table.
+ */
+function toggleExpandableElementsInNextRows(el) {
+    let columnAffected = 1;
+    let nearestParentRow = findNearestParentOfType(el, "tr");
+    let nearestParentTable = findNearestParentOfType(el, "table");
+
+    if (nearestParentRow && nearestParentTable) {
+        let rowsToExpand = [];
+        let allTableRows = qsa("tr", nearestParentTable);
+        let startingRowIndex = -1, endingRowIndex = -1;
+
+        // basically, the goal is to find all rows in between header rows. This will correspond to the rows which contain expandable items. For example, in the position details page, competencies have a header row, and then one row per competency. These are the rows we are trying to identify here in the next loops
+
+        for (let i = 0; i < allTableRows.length && startingRowIndex === -1; i++) {
+            let currentRow = allTableRows[i];
+            if (currentRow.contains(el)) {
+                startingRowIndex = i;
+            } // if
+        } // for
+
+        for (let i = startingRowIndex + 1; i < allTableRows.length && endingRowIndex === -1; i++) {
+            let currentRow = allTableRows[i];
+            let nodesInRow = qsa("*", currentRow);
+            for (let j = 0; j < nodesInRow.length; j++) {
+                if (nodesInRow[j].tagName.toLowerCase() === "th") {
+                    endingRowIndex = i;
+                } // if
+            } // for
+            if (i === allTableRows.length - 1 && endingRowIndex === -1) {
+                endingRowIndex = allTableRows.length;
+            } // if
+        } // for
+
+        rowsToExpand = allTableRows.slice(startingRowIndex + 1, endingRowIndex);
+
+        if (qsa(".collapsing", nearestParentTable).length === 0) { // this is to make sure that nothing happens if elements are currently being expanded/closed, otherwise the state might be slightly off
+        
+            if (qsa(".accordion", rowsToExpand[0]).length > 0) { // this is just to determine if there is something expandable in the rows, if not, there's no point in trying to expand the elements
+    
+                if (el.classList.contains("second-column")) { // this is for the competency rows/tables, where you can expand both the competency names or the levels associated to them
+                    columnAffected = 2;
+                } // if
+    
+                let expandingItems = el.classList.contains("closed");
+                if (expandingItems) {
+                    el.classList.remove("closed");
+                    el.classList.add("opened");
+                } // if
+                else {
+                    el.classList.add("closed");
+                    el.classList.remove("opened");
+                } // else
+
+                // in the case of the add/edit position page, all expandable elements will be within the same table row. However, each item will be within a separate div.row. So, if we only have one row, and that row has at least one div.row, instead of looping through multiple table rows, we will now loop through those div.row. The rest of the code behaves the same
+                if (qsa("td div.row", rowsToExpand[0]).length > 0 && rowsToExpand.length === 1) {
+                    rowsToExpand = qsa("td div.row", rowsToExpand[0]);
+                } // if
+    
+                for (let i = 0; i < rowsToExpand.length; i++) {
+                    let btnsInRow = qsa("button.btn", rowsToExpand[i]);
+            
+                    for (let i = 0; i < btnsInRow.length; i++) {
+                        if ((i + 1) === columnAffected) {
+                            if ((expandingItems && btnsInRow[i].getAttribute("aria-expanded") === "false") || (!expandingItems && btnsInRow[i].getAttribute("aria-expanded") === "true"))
+                            btnsInRow[i].click();
+                        } // if
+                    } // for
+                } // for
+            } // if
+        } // if
+    } // if
+} // toggleExpandableElementsInNextRows()
+
+/**
+ * 
+ * @param {HTMLElement} dropdown - The dropdown which had its value updated
+ * 
+ * This function gets called whenever a dropdown to change a competency's level gets updated, either by the dropdown itself, or by the + or - buttons. It ensures that if the dropdown is at its maximum or minimum value, the corresponding button gets disabled (and re-enabled if the value changes again and is no longer at an extreme).
+ */
+function checkCompetencyLevelButtonsState(dropdown) {
+    let dropDown = /** @type {HTMLInputElement} */ (dropdown);
+    let minusButton = dropDown.previousElementSibling;
+    let plusButton = dropDown.nextElementSibling;
+
+    let currentValue = Number(dropDown.value);
+    let maxValue = getMaximumOrMinimumValueFromDropdown(dropDown);
+    let minValue = getMaximumOrMinimumValueFromDropdown(dropDown, false);
+
+    minusButton.classList.remove("disabled");
+    plusButton.classList.remove("disabled");
+
+    if (currentValue === minValue) {
+        minusButton.classList.add("disabled");
+    } // if
+    if (currentValue === maxValue) {
+        plusButton.classList.add("disabled");
+    } // if
+} // checkCompetencyLevelButtonsState()
+
+/**
+ * 
+ * @param {HTMLElement} dropdown - The "select" HTML element
+ * @param {Boolean} maximum - True by default. If set to true, will return the maximum, and the minimum otherwise
+ * @returns Number
+ * 
+ * This function returns the maximum or minimum "value" attribute of all option elements contained within the dropdown. Returns null if there are no options in the dropdown.
+ */
+function getMaximumOrMinimumValueFromDropdown(dropdown, maximum = true) {
+    let dropdownOptions = qsa("option", dropdown);
+    if (dropdownOptions.length > 0) {
+        let dropdownValues = [];
+        for (let i = 0; i < dropdownOptions.length; i++) {
+            dropdownValues[i] = /** @type {Number} */ ((/** @type {HTMLInputElement} */ (dropdownOptions[i])).value);
+        } // for
+        return maximum ? Math.max(...dropdownValues) : Math.min(...dropdownValues);
+    } // if
+    return null;
+} // getMaximumValueFromDropdown()
+
+/**
+ * 
+ * @param {HTMLElement} el - The HTMLElement which caused the function to be called, either a + or - button, or a competency level dropdown
+ * @param {Number} newNum - The new competency level. It will be set if this function gets called by selecting the dropdown value
+ * 
+ * This function replaces all formaction attributes on the page (add/edit position) whenever a competency level is changed. In doing so, users are able to change the level of a competency without having to remove and add the competency again. If the function gets called by pressing the + or - button, this function also replaces the associated dropdown with the updated number.
+ */
+function changeCompetencyLevelValue(el, newNum = null) {
+    let newDropdownValue;
+    let valueChanged;
+    let dropdown;
+
+    if (newNum) {
+        valueChanged = true;
+        newDropdownValue = newNum;
+        dropdown = el;
+    } // if
+    else {
+        let increment = true;
+    
+        if (el.classList.contains("minus-icon")) {
+            dropdown = el.nextElementSibling;
+            increment = false;
+        } // if
+        else {
+            dropdown = el.previousElementSibling;
+        } // else
+        dropdown = /** @type {HTMLInputElement} */ (dropdown);
+    
+        let originalDropdownValue = Number(dropdown.value);
+        let maxDropdownValue = getMaximumOrMinimumValueFromDropdown(dropdown);
+        let minDropdownValue = getMaximumOrMinimumValueFromDropdown(dropdown, false);
+
+        if (increment && originalDropdownValue < maxDropdownValue) {
+            dropdown.value = originalDropdownValue + 1;
+        } // if
+        if (!increment && originalDropdownValue > minDropdownValue) {
+            dropdown.value = originalDropdownValue - 1;
+        } // if
+
+        newDropdownValue = Number(dropdown.value);
+        valueChanged = (originalDropdownValue !== newDropdownValue);
+    } // else
+
+    if (valueChanged) {
+        checkCompetencyLevelButtonsState(dropdown);
+        const ENCODED_AMPERSAND = encodeURIComponent("&");
+        let formActionElements = qsa(`[formaction]`);
+        let shortCompetencyStr = dropdown.id.substring(0, dropdown.id.indexOf("-"));
+        let fullCompetencyStr;
+        let compId = Number(dropdown.id.substring(dropdown.id.indexOf("-") + 1));
+
+        switch (shortCompetencyStr) {
+            case "know":
+                fullCompetencyStr = "addedknowledgecompetencyids";
+                break;
+            case "tech":
+                fullCompetencyStr = "addedtechnicalcompetencyids";
+                break;
+            case "beha":
+                fullCompetencyStr = "addedbehaviouralcompetencyids";
+                break;
+            case "exec":
+                fullCompetencyStr = "addedexecutivecompetencyids";
+                break;
+        } // switch
+        fullCompetencyStr = /** @type {String} */ (fullCompetencyStr);
+
+        for (let i = 0; i < formActionElements.length; i++) {
+            let formActionElement = formActionElements[i];
+            let formActionStr = formActionElement.getAttribute("formaction");  
+    
+            let competencyIdsStr = formActionStr.substring((formActionStr.indexOf(fullCompetencyStr) + fullCompetencyStr.length + 1), 
+                (formActionStr.indexOf("-&", (formActionStr.indexOf(fullCompetencyStr) + 1))));
+
+            let endIndex = competencyIdsStr.indexOf("-", (competencyIdsStr.indexOf(compId.toString().concat(ENCODED_AMPERSAND)))) < 0 ? competencyIdsStr.length :
+                competencyIdsStr.indexOf("-", (competencyIdsStr.indexOf(compId.toString().concat(ENCODED_AMPERSAND))));
+
+            let competencyToUpdateStr = competencyIdsStr.substring((competencyIdsStr.indexOf(compId.toString().concat(ENCODED_AMPERSAND))), 
+            endIndex);
+
+            let updatedCompetencyStr = competencyToUpdateStr.substring(0, competencyToUpdateStr.indexOf(ENCODED_AMPERSAND) + ENCODED_AMPERSAND.length).concat(newDropdownValue.toString());
+
+            let formActionStrArr = formActionStr.split('');
+            formActionStrArr.splice(formActionStr.indexOf(competencyToUpdateStr), competencyToUpdateStr.length, updatedCompetencyStr);
+            let updatedFormActionStr = formActionStrArr.join('');
+    
+            formActionElement.setAttribute("formaction", updatedFormActionStr);
+        } // for
+    } // if
+} // changeCompetencyLevelValue()
+
+/**
+ * 
+ * @param {Event} e - The change event
+ * @returns - void
+ * 
+ * This function gets called whenever an input element has its value change, and in certain cases, it will call other functions to handle special baheviour.
+ */
+ function handleChange(e) {
+    let target = /** @type {HTMLInputElement} */ (e.target);
+    if (target) {
+        if (target.classList) {
+            if (target.classList.contains("changeCompetencyLevelDropdown")) {
+                changeCompetencyLevelValue(target, target.value);
+                return;
+            } // if
+        } // if
+    } // if
+} // handleChange()
+
+/**
+ * 
+ * @param {Event} e - The click event
+ * @returns - void
+ * 
+ * This function gets called whenever something is clicked on the page, to then dispatch the event to another function based on what was clicked and if something should happen in that case.
+ */
+ function handleClick(e) {
+    let target = /** @type {HTMLElement} */ (e.target);
+    if (target) {
+        if (target.classList) {
+            if (target.classList.contains("resetWindowHeight")) {
+                storeCurrentScrollPosition();
+                return;
+            } // if
+            if (target.classList.contains("expand-elements-in-next-rows")) {
+                toggleExpandableElementsInNextRows(target);
+                return;
+            } // if
+            if (target.classList.contains("plus-minus-icon")) {
+                changeCompetencyLevelValue(target);
+                return;
+            } // if
+        } // if
+        if (target.id) {
+            if (target.id === "allRegionsCheckbox") {
+                toggleRegionCheckboxes();
+                return;
+            } // if
+        } // if
+    } // if
+} // handleClick()
+
+// Page setup when it has loaded. Adds the appropriate event listeners and such
+window.addEventListener("load", () => {
+    windowHeight = window.innerHeight;
+    tableContainer = qs("#table-container");
+    footer = qs("footer");
+    qs("body").addEventListener("click", (e) => {
+        handleClick(e);
+    });
+    qs("body").addEventListener("change", (e) => {
+        handleChange(e);
+    });
+
+    checkIfWindowShouldBeScrolled();
+
+    if (tableContainer && footer) {
+        setTableContainerMaxHeight();
+        window.addEventListener("resize", () => {
+            windowHeight = window.innerHeight;
+            setTableContainerMaxHeight();
+        });
+    } // if
+});


### PR DESCRIPTION
This PR also includes other small fixes to the index pages:

-The "Back to full list" link only displays when you actually have a search filter (non whitespace)
-The competency index has navigation to the different types of competencies
-The certificates/certificate descriptions index has a quick navigation between the two
-The search now works on job level in both the positions index and search similar positions index
-There is a message when a search doesn't return any results (on any page)
-Made it so all index pages display alphabetically (in the case of positions, they are sorted first by their level, and then their English title)
-On the Similar Positions Index, added an option to see how many similar jobs each position has per percentage threshold (by default, this is not displayed) 

-This PR includes the changes made to the site.js, which includes features used by this batch and many others down the line