### PR TITLE
Added cancel buttons and made inactive elements inaccessible

### DIFF
--- a/Admin/Pages/Certificates/Create.cshtml
+++ b/Admin/Pages/Certificates/Create.cshtml
@@ -10,31 +10,33 @@
 <h4>Certificate</h4>
 <hr />
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-6">
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <div class="form-group">
                 <label asp-for="Certificate.NameEng" class="control-label"></label>
-                <input asp-for="Certificate.NameEng" class="form-control" required />
+                <textarea class="form-control" asp-for="Certificate.NameEng" required></textarea>
                 <span asp-validation-for="Certificate.NameEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.NameFre" class="control-label"></label>
-                <input asp-for="Certificate.NameFre" class="form-control" required />
+                <textarea asp-for="Certificate.NameFre" class="form-control" required></textarea>
                 <span asp-validation-for="Certificate.NameFre" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
-                <input asp-for="Certificate.DescEng" class="form-control" />
+                <textarea asp-for="Certificate.DescEng" class="form-control"></textarea>
                 <span asp-validation-for="Certificate.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescFre" class="control-label"></label>
-                <input asp-for="Certificate.DescFre" class="form-control" />
+                <textarea asp-for="Certificate.DescFre" class="form-control"></textarea>
                 <span asp-validation-for="Certificate.DescFre" class="text-danger"></span>
             </div>
-            <div class="form-group">
+
+            <div class="form-group space-btns medium-margin-top padding-top">
                 <input type="submit" value="Create" class="btn btn-primary" />
+                <a class="btn btn-secondary" href="/Certificates">Cancel</a>
             </div>
         </form>
     </div>

--- a/Admin/Pages/Certificates/Delete.cshtml
+++ b/Admin/Pages/Certificates/Delete.cshtml
@@ -9,9 +9,8 @@
 
 <p class="text-danger">@Model.ErrorMessage</p>
 
-<h3>Are you sure you want to delete this?</h3>
 <div>
-    <h4>Certificate</h4>
+    <h4>Are you sure you want to delete this certificate?</h4>
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
@@ -29,20 +28,45 @@
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Certificate.DescEng)
         </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Certificate.DescEng)
-        </dd>
+        @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescEng))
+        {
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Certificate.DescEng)
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-10 bold">
+                Not provided
+            </dd>
+        }
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Certificate.DescFre)
         </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Certificate.DescFre)
-        </dd>
+        @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescFre))
+        {
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Certificate.DescFre)
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-10 bold">
+                Not provided
+            </dd>
+        }
     </dl>
     
     <form method="post">
         <input type="hidden" asp-for="Certificate.Id" />
-        <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-page="./Index">Back to List</a>
+
+        <div class="form-group space-btns">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+            <a class="btn btn-secondary" href="/Certificates/Details?id=@Model.Certificate.Id">Cancel</a>
+        </div>
     </form>
+</div>
+
+<div>
+    <a asp-page="./Index">Back to List</a>
 </div>

--- a/Admin/Pages/Certificates/Delete.cshtml.cs
+++ b/Admin/Pages/Certificates/Delete.cshtml.cs
@@ -43,6 +43,10 @@ namespace Admin.Pages.Certificates
             {
                 return NotFound();
             }
+            if (Certificate.Active != 1)
+            {
+                return NotFound();
+            }
             if (saveChangesError.GetValueOrDefault())
             {
                 ErrorMessage = String.Format("Delete {ID} failed. Try again", id);

--- a/Admin/Pages/Certificates/Descriptions/Create.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Create.cshtml
@@ -15,16 +15,18 @@
             <input type="hidden" asp-for="Certificate.Id" />
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
-                <input asp-for="Certificate.DescEng" class="form-control" />
+                <textarea asp-for="Certificate.DescEng" class="form-control" required></textarea>
                 <span asp-validation-for="Certificate.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescFre" class="control-label"></label>
-                <input asp-for="Certificate.DescFre" class="form-control" />
+                <textarea asp-for="Certificate.DescFre" class="form-control" required></textarea>
                 <span asp-validation-for="Certificate.DescFre" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <input type="submit" value="Save" class="btn btn-primary" />
+
+             <div class="form-group space-btns medium-margin-top padding-top">
+                <input type="submit" value="Create" class="btn btn-primary" />
+                <a class="btn btn-secondary" href="/Certificates/Descriptions">Cancel</a>
             </div>
         </form>
     </div>

--- a/Admin/Pages/Certificates/Descriptions/Delete.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Delete.cshtml
@@ -8,9 +8,8 @@
 
 <p class="text-danger">@Model.ErrorMessage</p>
 
-<h3>Are you sure you want to delete this?</h3>
 <div>
-    <h4>Certificate</h4>
+    <h4>Are you sure you want to delete this certificate description?</h4>
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
@@ -29,7 +28,14 @@
 
     <form method="post">
         <input type="hidden" asp-for="Certificate.Id" />
-        <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-page="./Index">Back to List</a>
+
+        <div class="form-group space-btns">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+            <a class="btn btn-secondary" href="/Certificates/Descriptions/Details?id=@Model.Certificate.Id">Cancel</a>
+        </div>
     </form>
+</div>
+
+<div>
+    <a asp-page="./Index">Back to List</a>
 </div>

--- a/Admin/Pages/Certificates/Descriptions/Delete.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Delete.cshtml.cs
@@ -47,7 +47,8 @@ namespace Admin.Pages.Certificates.Descriptions
                 return NotFound();
             }
 
-            // this is debatable, but I've made it so you can't view/edit/delete the description that is empty, since it is kind of unique
+            // the empty certificate description should not be accessible directly from the index page, since it is unique.
+            // It shouldn't be mofidied, deleted, or viewed, it should simply be an option to select when adding a certificate to a position
             if (string.IsNullOrWhiteSpace(Certificate.DescEng) && string.IsNullOrWhiteSpace(Certificate.DescFre))
             {
                 return NotFound();

--- a/Admin/Pages/Certificates/Descriptions/Details.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Details.cshtml
@@ -1,5 +1,8 @@
 ﻿@page
 @model Admin.Pages.Certificates.Descriptions.DetailsModel
+@{
+    ViewData["Title"] = "Details";
+}
 
 <h1>Details</h1>
 

--- a/Admin/Pages/Certificates/Descriptions/Details.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Details.cshtml.cs
@@ -1,23 +1,53 @@
 ﻿using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using DataModel;
 using Business.Dtos.JobCompetencies;
+using Microsoft.Extensions.Logging;
 using Admin.Data;
+using System.Threading;
+
 namespace Admin.Pages.Certificates.Descriptions
 {
     public class DetailsModel : PageModel
     {
+        private readonly DataModel.CctDbContext _context;
+        private readonly ILogger<EditModel> _logger;
         private readonly JobCertificateService _jobCertificateService;
 
-        public DetailsModel(JobCertificateService jobCertificateService)
+        public DetailsModel(CctDbContext context, ILogger<EditModel> logger, JobCertificateService jobCertificateService)
         {
+            _context = context;
+            _logger = logger;
             _jobCertificateService = jobCertificateService;
         }
 
-        public JobCertificateDto Description { get; set; }
+        public CertificateDescription Description { get; set; }
 
-        public async Task OnGetAsync(int id)
+        public async Task<IActionResult> OnGetAsync(int? id)
         {
-            Description = await _jobCertificateService.GetJobCertificateDescriptionById(id);
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            Description = await _context.CertificateDescriptions.FindAsync(id);
+            if (Description == null)
+            {
+                return NotFound();
+            }
+            if (Description.Active != 1)
+            {
+                return NotFound();
+            }
+
+            // this is debatable, but I've made it so you can't view/edit/delete the description that is empty, since it is kind of unique
+            if (string.IsNullOrWhiteSpace(Description.DescEng) && string.IsNullOrWhiteSpace(Description.DescFre))
+            {
+                return NotFound();
+            }
+
+            return Page();
         }
     }
 }

--- a/Admin/Pages/Certificates/Descriptions/Details.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Details.cshtml.cs
@@ -41,7 +41,8 @@ namespace Admin.Pages.Certificates.Descriptions
                 return NotFound();
             }
 
-            // this is debatable, but I've made it so you can't view/edit/delete the description that is empty, since it is kind of unique
+            // the empty certificate description should not be accessible directly from the index page, since it is unique.
+            // It shouldn't be mofidied, deleted, or viewed, it should simply be an option to select when adding a certificate to a position
             if (string.IsNullOrWhiteSpace(Description.DescEng) && string.IsNullOrWhiteSpace(Description.DescFre))
             {
                 return NotFound();

--- a/Admin/Pages/Certificates/Descriptions/Edit.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Edit.cshtml
@@ -9,22 +9,24 @@
 <h4>Certificate Description</h4>
 <hr />
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-6">
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Certificate.Id" />
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
-                <input asp-for="Certificate.DescEng" class="form-control" />
+                <textarea asp-for="Certificate.DescEng" class="form-control" required></textarea>
                 <span asp-validation-for="Certificate.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescFre" class="control-label"></label>
-                <input asp-for="Certificate.DescFre" class="form-control" />
+                <textarea asp-for="Certificate.DescFre" class="form-control" required></textarea>
                 <span asp-validation-for="Certificate.DescFre" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <input type="submit" value="Save" class="btn btn-primary" />
+
+            <div class="form-group space-btns medium-margin-top padding-top">
+                <input type="submit" value="Save Changes" class="btn btn-primary" />
+                <a class="btn btn-secondary" href="/Certificates/Descriptions/Details?id=@Model.Certificate.Id">Cancel</a>
             </div>
         </form>
     </div>

--- a/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
@@ -38,6 +38,17 @@ namespace Admin.Pages.Certificates.Descriptions
             {
                 return NotFound();
             }
+            if (Certificate.Active != 1)
+            {
+                return NotFound();
+            }
+
+            // this is debatable, but I've made it so you can't view/edit the description that is empty, since it is kind of unique
+            if (string.IsNullOrWhiteSpace(Certificate.DescEng) && string.IsNullOrWhiteSpace(Certificate.DescFre))
+            {
+                return NotFound();
+            }
+
             return Page();
         }
 

--- a/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
@@ -43,7 +43,8 @@ namespace Admin.Pages.Certificates.Descriptions
                 return NotFound();
             }
 
-            // this is debatable, but I've made it so you can't view/edit the description that is empty, since it is kind of unique
+            // the empty certificate description should not be accessible directly from the index page, since it is unique.
+            // It shouldn't be mofidied, deleted, or viewed, it should simply be an option to select when adding a certificate to a position
             if (string.IsNullOrWhiteSpace(Certificate.DescEng) && string.IsNullOrWhiteSpace(Certificate.DescFre))
             {
                 return NotFound();

--- a/Admin/Pages/Certificates/Details.cshtml
+++ b/Admin/Pages/Certificates/Details.cshtml
@@ -26,15 +26,33 @@
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Certificate.DescEng)
         </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Certificate.DescEng)
-        </dd>
+        @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescEng))
+        {
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Certificate.DescEng)
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-10 bold">
+                Not provided
+            </dd>
+        }
         <dt class="col-sm-2">
             @Html.DisplayNameFor(model => model.Certificate.DescFre)
         </dt>
-        <dd class="col-sm-10">
-            @Html.DisplayFor(model => model.Certificate.DescFre)
-        </dd>
+        @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescFre))
+        {
+            <dd class="col-sm-10">
+                @Html.DisplayFor(model => model.Certificate.DescFre)
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-10 bold">
+                Not provided
+            </dd>
+        }
     </dl>
 </div>
 <div>

--- a/Admin/Pages/Certificates/Details.cshtml.cs
+++ b/Admin/Pages/Certificates/Details.cshtml.cs
@@ -2,6 +2,7 @@
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Business.Dtos.JobCompetencies;
 using Admin.Data;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Admin.Pages.Certificates
 {
@@ -16,9 +17,22 @@ namespace Admin.Pages.Certificates
 
         public JobCertificateDto Certificate { get; set; }
 
-        public async Task OnGetAsync(int id)
+        public async Task<IActionResult> OnGetAsync(int? id)
         {
-            Certificate = await _jobCertificateService.GetJobCertificateById(id); 
+            if (id == null)
+            {
+                return NotFound();
+            }
+            Certificate = await _jobCertificateService.GetJobCertificateById(id.Value);
+            if (Certificate == null)
+            {
+                return NotFound();
+            }
+            if (Certificate.Active != 1)
+            {
+                return NotFound();
+            }
+            return Page();
         }
     }
 }

--- a/Admin/Pages/Certificates/Edit.cshtml
+++ b/Admin/Pages/Certificates/Edit.cshtml
@@ -10,32 +10,34 @@
 <h4>Certificate</h4>
 <hr />
 <div class="row">
-    <div class="col-md-4">
+    <div class="col-md-6">
         <form method="post">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Certificate.Id" />
             <div class="form-group">
                 <label asp-for="Certificate.NameEng" class="control-label"></label>
-                <input asp-for="Certificate.NameEng" class="form-control" required />
+                <textarea class="form-control" asp-for="Certificate.NameEng" required></textarea>
                 <span asp-validation-for="Certificate.NameEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.NameFre" class="control-label"></label>
-                <input asp-for="Certificate.NameFre" class="form-control" required />
+                <textarea asp-for="Certificate.NameFre" class="form-control" required></textarea>
                 <span asp-validation-for="Certificate.NameFre" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
-                <input asp-for="Certificate.DescEng" class="form-control" />
+                <textarea asp-for="Certificate.DescEng" class="form-control"></textarea>
                 <span asp-validation-for="Certificate.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescFre" class="control-label"></label>
-                <input asp-for="Certificate.DescFre" class="form-control" />
+                <textarea asp-for="Certificate.DescFre" class="form-control"></textarea>
                 <span asp-validation-for="Certificate.DescFre" class="text-danger"></span>
             </div>
-            <div class="form-group">
-                <input type="submit" value="Save" class="btn btn-primary" />
+
+            <div class="form-group space-btns medium-margin-top padding-top">
+                <input type="submit" value="Save Changes" class="btn btn-primary" />
+                <a class="btn btn-secondary" href="/Certificates/Details?id=@Model.Certificate.Id">Cancel</a>
             </div>
         </form>
     </div>

--- a/Admin/Pages/Certificates/Edit.cshtml.cs
+++ b/Admin/Pages/Certificates/Edit.cshtml.cs
@@ -44,6 +44,10 @@ namespace Admin.Pages.Certificates
             {
                 return NotFound();
             }
+            if (Certificate.Active != 1)
+            {
+                return NotFound();
+            }
             return Page();
         }
 

--- a/Admin/Pages/Competencies/Create.cshtml
+++ b/Admin/Pages/Competencies/Create.cshtml
@@ -1,17 +1,18 @@
 ﻿@page
 @model Admin.Pages.Competencies.CreateModel
 @{
-    ViewData["Title"] = "Create New Competency";
+    ViewData["Title"] = "Create";
 }
 
-<h1>Create a new Competency</h1>
+<h1>Create</h1>
 
+<h4>Competency</h4>
 <hr />
 
 <div class="col-md-12">
     <form method="post">
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-        <h3 style="margin-bottom:15px;">Choose a competency to add</h3>
+        <h3 style="margin-bottom:15px;">Choose the competency type</h3>
         <div class="form-group">
             <input type="radio" id="knowledge" asp-for="@Model.TypeId" name="CompetencyType" value="1">
             <label class="h5 mr-md-3" asp-for="@Model.TypeId" for="knowledge">Knowledge</label>
@@ -42,7 +43,9 @@
             <textarea asp-for="Competency.DescFre" class="form-control" rows="5" cols="50"></textarea>
             <span asp-validation-for="Competency.DescFre" class="text-danger"></span>
         </div>
-        <h3 style="margin-bottom:15px;">Add a description for each Level</h3>
+
+        <h3 class="small-margin-bottom small-margin-top">Add a description for each level</h3>
+
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 1 - English</b></label>
@@ -103,14 +106,16 @@
                 <span asp-validation-for="Competency.Level5DescFre" class="text-danger"></span>
             </div>
         </div>
-        <div class="form-group">
+
+        <div class="form-group space-btns padding-top">
             <input type="submit" value="Create" class="btn btn-primary" />
+            <a class="btn btn-secondary" asp-page="List" asp-route-typeid="@Model.TypeId">Cancel</a>
         </div>
     </form>
 </div>
 
 
-<div>
+<div class="padding-left">
     <a asp-page="List" asp-route-typeid="@Model.TypeId">Back to List</a>
 </div>
 

--- a/Admin/Pages/Competencies/Create.cshtml.cs
+++ b/Admin/Pages/Competencies/Create.cshtml.cs
@@ -4,6 +4,8 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using Admin.Data;
 using Business.Dtos.JobCompetencies;
 using System.Threading;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace Admin.Pages.Competencies
 {
@@ -18,15 +20,28 @@ namespace Admin.Pages.Competencies
             _jobCompetencyService = jobCompetencyService;
         }
 
-        public IActionResult OnGet()
+        public IActionResult OnGet(int? typeid)
         {
+            if (typeid == null)
+            {
+                return Redirect("/Competencies/Create?typeid=1");
+            }
+            else
+            {
+                int[] typeids = { 1, 2, 3, 4 };
+                if (!typeids.Contains(typeid.Value))
+                {
+                    return Redirect("/Competencies/Create?typeid=1");
+                }
+            }
+
             return Page();
         }
 
         [BindProperty]
         public JobCompetencyDto Competency { get; set; }
         [BindProperty(SupportsGet = true)]
-        public int TypeId { get; set; } = 1;
+        public int TypeId { get; set; }
 
         [BindProperty]
         public int CompetencyType { get; set; } 

--- a/Admin/Pages/Competencies/Delete.cshtml
+++ b/Admin/Pages/Competencies/Delete.cshtml
@@ -8,9 +8,9 @@
 
 <p class="text-danger">@Model.ErrorMessage</p>
 
-<h3>Are you sure you want to delete this?</h3>
 <div>
-    <h4>Competency</h4>
+    <h4>Are you sure you want to delete this 
+    @Model.Competency.TypeNameEng.Substring(0, Model.Competency.TypeNameEng.IndexOf(" ")).ToLower() competency?</h4>
     <hr />
     <dl class="row">
         <dt class="col-sm-2">
@@ -41,8 +41,15 @@
 
     <form method="post">
         <input type="hidden" asp-for="Competency.Id" />
-        <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-page="List" asp-route-typeid="@Model.Competency.TypeId">Back to List</a>
+
+        <div class="form-group space-btns">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+            <a class="btn btn-secondary" href="/Competencies/Details?id=@Model.Competency.Id">Cancel</a>
+        </div>
     </form>
+</div>
+
+<div>
+    <a asp-page="List" asp-route-typeid="@Model.Competency.TypeId">Back to List</a>
 </div>
 

--- a/Admin/Pages/Competencies/Delete.cshtml.cs
+++ b/Admin/Pages/Competencies/Delete.cshtml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
@@ -36,11 +38,23 @@ namespace Admin.Pages.Competencies
                 return NotFound();
             }
 
+            var compExists = _context.Competencies.Where(x => x.Id == id.Value).FirstOrDefault();
+
+            if (compExists == null)
+            {
+                return NotFound();
+            }
+            if (compExists.Active != 1)
+            {
+                return NotFound();
+            }
+
             Competency = await _jobCompetencyService.GetJobCompetencyById(id);
             if (Competency == null)
             {
                 return NotFound();
             }
+
             if (saveChangesError.GetValueOrDefault())
             {
                 ErrorMessage = String.Format("Delete {ID} failed. Try again", id);

--- a/Admin/Pages/Competencies/Details.cshtml
+++ b/Admin/Pages/Competencies/Details.cshtml
@@ -1,45 +1,47 @@
 ﻿@page
 @model Admin.Pages.Competencies.DetailsModel
 @{
-    ViewData["Title"] = "Knowledge Details";
+    ViewData["Title"] = "Details";
 }
 
-<div style="margin-top:55px;">
+<h1>Details</h1>
+
+<div class="small-margin-bottom">
     <h4>@Html.DisplayFor(model => model.Competency.NameEng) / @Html.DisplayFor(model => model.Competency.NameFre)</h4>
     <hr />
-    <dl class="row border-bottom">
+    <dl class="row border-bottom small-padding-bottom">
         <dt class="col-md-2">
-            Name English
+            @Html.DisplayNameFor(model => model.Competency.NameEng)
         </dt>
         <dd class="col-md-10">
             @Html.DisplayFor(model => model.Competency.NameEng)
         </dd>
         <dt class="col-md-2">
-            Name French
+            @Html.DisplayNameFor(model => model.Competency.NameFre)
         </dt>
         <dd class="col-md-10">
             @Html.DisplayFor(model => model.Competency.NameFre)
         </dd>
         <dt class="col-md-2">
-            Description English
+            @Html.DisplayNameFor(model => model.Competency.DescEng)
         </dt>
         <dd class="col-md-10">
             @Html.DisplayFor(model => model.Competency.DescEng)
         </dd>
         <dt class="col-md-2">
-            Description French
+            @Html.DisplayNameFor(model => model.Competency.DescFre)
         </dt>
         <dd class="col-md-10">
             @Html.DisplayFor(model => model.Competency.DescFre)
         </dd>
         <dt class="col-md-2">
-            Type Name English
+            @Html.DisplayNameFor(model => model.Competency.TypeNameEng)
         </dt>
         <dd class="col-md-10">
             @Html.DisplayFor(model => model.Competency.TypeNameEng)
         </dd>
         <dt class="col-md-2">
-            Type Name French
+            @Html.DisplayNameFor(model => model.Competency.TypeNameFre)
         </dt>
         <dd class="col-md-10">
             @Html.DisplayFor(model => model.Competency.TypeNameFre)
@@ -49,61 +51,51 @@
 <div class="row">
     <div class="form-group col-md-6">
         <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 1 - English</b></label>
-        <textarea asp-for="Competency.Level1DescEng" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level1DescEng" class="text-danger"></span>
+        <p class="comp-details-level">@Model.Competency.Level1DescEng</p>
     </div>
     <div class="form-group col-md-6">
         <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 1 - French</b></label>
-        <textarea asp-for="Competency.Level1DescFre" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level1DescFre" class="text-danger"></span>
+        <p class="comp-details-level">@Model.Competency.Level1DescFre</p>
     </div>
 </div>
 <div class="row">
     <div class="form-group col-md-6">
-        <label asp-for="Competency.Level2DescEng" class="control-label"><b>Level 2 - English</b></label>
-        <textarea asp-for="Competency.Level2DescEng" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level2DescEng" class="text-danger"></span>
+        <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 2 - English</b></label>
+        <p class="comp-details-level">@Model.Competency.Level2DescEng</p>
     </div>
     <div class="form-group col-md-6">
-        <label asp-for="Competency.Level2DescFre" class="control-label"><b>Level 2 - French</b></label>
-        <textarea asp-for="Competency.Level2DescFre" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level2DescFre" class="text-danger"></span>
+        <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 2 - French</b></label>
+        <p class="comp-details-level">@Model.Competency.Level2DescFre</p>
+    </div>
+</div>
+<div class="row">
+   <div class="form-group col-md-6">
+        <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 3 - English</b></label>
+        <p class="comp-details-level">@Model.Competency.Level3DescEng</p>
+    </div>
+    <div class="form-group col-md-6">
+        <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 3 - French</b></label>
+        <p class="comp-details-level">@Model.Competency.Level3DescFre</p>
     </div>
 </div>
 <div class="row">
     <div class="form-group col-md-6">
-        <label asp-for="Competency.Level3DescEng" class="control-label"><b>Level 3 - English</b></label>
-        <textarea asp-for="Competency.Level3DescEng" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level3DescEng" class="text-danger"></span>
+        <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 4 - English</b></label>
+        <p class="comp-details-level">@Model.Competency.Level4DescEng</p>
     </div>
     <div class="form-group col-md-6">
-        <label asp-for="Competency.Level3DescFre" class="control-label"><b>Level 3 - French</b></label>
-        <textarea asp-for="Competency.Level3DescFre" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level3DescFre" class="text-danger"></span>
+        <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 4 - French</b></label>
+        <p class="comp-details-level">@Model.Competency.Level4DescFre</p>
     </div>
 </div>
 <div class="row">
-    <div class="form-group col-md-6">
-        <label asp-for="Competency.Level4DescEng" class="control-label"><b>Level 4 - English</b></label>
-        <textarea asp-for="Competency.Level4DescEng" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level4DescEng" class="text-danger"></span>
+   <div class="form-group col-md-6">
+        <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 5 - English</b></label>
+        <p class="comp-details-level">@Model.Competency.Level5DescEng</p>
     </div>
     <div class="form-group col-md-6">
-        <label asp-for="Competency.Level4DescFre" class="control-label"><b>Level 4 - French</b></label>
-        <textarea asp-for="Competency.Level4DescFre" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level4DescFre" class="text-danger"></span>
-    </div>
-</div>
-<div class="row">
-    <div class="form-group col-md-6">
-        <label asp-for="Competency.Level5DescEng" class="control-label"><b>Level 5 - English</b></label>
-        <textarea asp-for="Competency.Level5DescEng" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level5DescEng" class="text-danger"></span>
-    </div>
-    <div class="form-group col-md-6">
-        <label asp-for="Competency.Level5DescFre" class="control-label"><b>Level 5 - French</b></label>
-        <textarea asp-for="Competency.Level5DescFre" class="form-control" rows="3" cols="45"></textarea>
-        <span asp-validation-for="Competency.Level5DescFre" class="text-danger"></span>
+        <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 5 - French</b></label>
+        <p class="comp-details-level">@Model.Competency.Level5DescFre</p>
     </div>
 </div>
 

--- a/Admin/Pages/Competencies/Details.cshtml.cs
+++ b/Admin/Pages/Competencies/Details.cshtml.cs
@@ -24,25 +24,116 @@ namespace Admin.Pages.Competencies
         }
         public JobCompetencyDto Competency { get; set; }
 
-        public async Task OnGetAsync(int id)
+        public async Task<IActionResult> OnGetAsync(int? id)
         {
+            if (id == null)
+            {
+                return NotFound();
+            }
+
+            var compExists = _context.Competencies.Where(x => x.Id == id.Value).FirstOrDefault();
+
+            if (compExists == null)
+            {
+                return NotFound();
+            }
+            if (compExists.Active != 1)
+            {
+                return NotFound();
+            }
+
             Competency = await _jobCompetencyService.GetJobCompetencyById(id);
-           
-            Competency.Level1DescEng =_jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescEng;
-            Competency.Level1DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescFre;
 
-            Competency.Level2DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescEng;
-            Competency.Level2DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescFre;
-         
-            Competency.Level3DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescEng;
-            Competency.Level3DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescFre;
-        
-            Competency.Level4DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescEng;
-            Competency.Level4DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescFre;
+            try
+            {
+                Competency.Level1DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level1DescEng = "";
+            }
+            try
+            {
+                Competency.Level1DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level1DescFre = "";
+            }
 
-            Competency.Level5DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescEng;         
-            Competency.Level5DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescFre;
 
+            try
+            {
+                Competency.Level2DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level2DescEng = "";
+            }
+            try
+            {
+                Competency.Level2DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level2DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level3DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level3DescEng = "";
+            }
+            try
+            {
+                Competency.Level3DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level3DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level4DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level4DescEng = "";
+            }
+            try
+            {
+                Competency.Level4DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level4DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level5DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level5DescEng = "";
+            }
+            try
+            {
+                Competency.Level5DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level5DescFre = "";
+            }
+
+            return Page();
         }
     }
 }

--- a/Admin/Pages/Competencies/Edit.cshtml
+++ b/Admin/Pages/Competencies/Edit.cshtml
@@ -6,7 +6,7 @@
 
 <h1>Edit</h1>
 
-<h4>Competency</h4>
+<h4>@Model.Competency.TypeNameEng.Substring(0, Model.Competency.TypeNameEng.IndexOf(" ")) Competency</h4>
 <hr />
 <div class="row">
     <div class="col-md-12">
@@ -94,8 +94,10 @@
                     <span asp-validation-for="Competency.Level5DescFre" class="text-danger"></span>
                 </div>
             </div>
-            <div class="form-group">
-                <input type="submit" value="Save" class="btn btn-primary" />
+
+            <div class="form-group space-btns padding-top">
+                <input type="submit" value="Save Changes" class="btn btn-primary" />
+                <a class="btn btn-secondary" href="/Competencies/Details?id=@Model.Competency.Id">Cancel</a>
             </div>
         </form>
     </div>

--- a/Admin/Pages/Competencies/Edit.cshtml.cs
+++ b/Admin/Pages/Competencies/Edit.cshtml.cs
@@ -34,27 +34,112 @@ namespace Admin.Pages.Competencies
                 return NotFound();
             }
 
-            //Competency = await _context.Competencies.FirstOrDefaultAsync(m => m.Id == id);
+            var compExists = _context.Competencies.Where(x => x.Id == id.Value).FirstOrDefault();
+
+            if (compExists == null)
+            {
+                return NotFound();
+            }
+            if (compExists.Active != 1)
+            {
+                return NotFound();
+            }
+
             Competency = await _jobCompetencyService.GetJobCompetencyById(id);
-
-            Competency.Level1DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescEng;
-            Competency.Level1DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescFre;
-
-            Competency.Level2DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescEng;
-            Competency.Level2DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescFre;
-
-            Competency.Level3DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescEng;
-            Competency.Level3DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescFre;
-
-            Competency.Level4DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescEng;
-            Competency.Level4DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescFre;
-
-            Competency.Level5DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescEng;
-            Competency.Level5DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescFre;
             if (Competency == null)
             {
                 return NotFound();
             }
+
+            try
+            {
+                Competency.Level1DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level1DescEng = "";
+            }
+            try
+            {
+                Competency.Level1DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level1DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level2DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level2DescEng = "";
+            }
+            try
+            {
+                Competency.Level2DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level2DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level3DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level3DescEng = "";
+            }
+            try
+            {
+                Competency.Level3DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level3DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level4DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level4DescEng = "";
+            }
+            try
+            {
+                Competency.Level4DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level4DescFre = "";
+            }
+
+
+            try
+            {
+                Competency.Level5DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescEng;
+            }
+            catch
+            {
+                Competency.Level5DescEng = "";
+            }
+            try
+            {
+                Competency.Level5DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescFre;
+            }
+            catch
+            {
+                Competency.Level5DescFre = "";
+            }
+
             return Page();
         }
 

--- a/Admin/Pages/Index.cshtml
+++ b/Admin/Pages/Index.cshtml
@@ -1,7 +1,7 @@
 ﻿@page
 @model IndexModel
 @{
-    ViewData["Title"] = "Home page";
+    ViewData["Title"] = "Home Page";
 }
 
 
@@ -12,7 +12,7 @@
                 <div class="card-body">
                     <h5 class="card-title">Certificates</h5>
                     <p class="card-text">Click here to create, view or edit certificates or certificate descriptions.</p>
-                    <a href="./Certificates" class="btn btn-primary">Edit</a>
+                    <a href="./Certificates" class="btn btn-primary">View</a>
                 </div>
             </div>
         </div>
@@ -21,7 +21,7 @@
                 <div class="card-body">
                     <h5 class="card-title">Competencies</h5>
                     <p class="card-text">Click here to create, view or edit competencies and competency level definitions.</p>
-                    <a href="./Competencies" class="btn btn-primary">Edit</a>
+                    <a href="./Competencies" class="btn btn-primary">View</a>
                 </div>
             </div>
         </div>
@@ -30,7 +30,7 @@
                 <div class="card-body">
                     <h5 class="card-title">Positions</h5>
                     <p class="card-text">Click here to create, view or edit job positions within the CCG.</p>
-                    <a href="./Positions" class="btn btn-primary">Edit</a>
+                    <a href="./Positions" class="btn btn-primary">View</a>
                 </div>
             </div>
         </div>
@@ -38,8 +38,8 @@
             <div class="card" style="width: 20rem;">
                 <div class="card-body">
                     <h5 class="card-title">Similar Positions</h5>
-                    <p class="card-text">Click here to create similar positions by selecting and editing similar positions for each of the matching scores; 100%, 90%, 80% and 70%.</p>
-                    <a href="./Similar" class="btn btn-primary">Edit</a>
+                    <p class="card-text">Click here to create, view or edit similar positions by selecting and editing similar positions for each of the matching scores: 100%, 90%, 80% and 70%.</p>
+                    <a href="./Similar" class="btn btn-primary">View</a>
                 </div>
             </div>
         </div>

--- a/Admin/Pages/Positions/Delete.cshtml
+++ b/Admin/Pages/Positions/Delete.cshtml
@@ -8,41 +8,64 @@
 
 <p class="text-danger">@Model.ErrorMessage</p>
 
-<h3>Are you sure you want to delete this?</h3>
 <div>
-    <h4>JobPosition</h4>
+    <h4>Are you sure you want to delete this position?</h4>
     <hr />
     <dl class="row">
         <dt class="col-sm-3">
-           Title English
+           @Html.DisplayNameFor(model => model.JobPosition.TitleEng)
         </dt>
         <dd class="col-sm-9">
             @Html.DisplayFor(model => model.JobPosition.TitleEng)
         </dd>
         <dt class="col-sm-3">
-            Title French
+            @Html.DisplayNameFor(model => model.JobPosition.TitleFre)
         </dt>
         <dd class="col-sm-9">
             @Html.DisplayFor(model => model.JobPosition.TitleFre)
         </dd>
-    </dl>
-    <dl class="row">
         <dt class="col-sm-3">
-           Position Description English
+           @Html.DisplayNameFor(model => model.JobPosition.PositionDescEng)
         </dt>
-        <dd class="col-sm-9">
-            @Html.DisplayFor(model => model.JobPosition.PositionDescEng)
-        </dd>
+        @if (!string.IsNullOrWhiteSpace(Model.JobPosition.PositionDescEng))
+        {
+            <dd class="col-sm-9">
+                @Html.DisplayFor(model => model.JobPosition.PositionDescEng)
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-9 bold">
+                Not provided
+            </dd>
+        }
         <dt class="col-sm-3">
-            Position Description French
+            @Html.DisplayNameFor(model => model.JobPosition.PositionDescFre)
         </dt>
-        <dd class="col-sm-9">
-            @Html.DisplayFor(model => model.JobPosition.PositionDescFre)
-        </dd>
+        @if (!string.IsNullOrWhiteSpace(Model.JobPosition.PositionDescFre))
+        {
+            <dd class="col-sm-9">
+                @Html.DisplayFor(model => model.JobPosition.PositionDescFre)
+            </dd>
+        }
+        else
+        {
+            <dd class="col-sm-9 bold">
+                Not provided
+            </dd>
+        }
     </dl>
+
     <form method="post">
         <input type="hidden" asp-for="JobPosition.Id" />
-        <input type="submit" value="Delete" class="btn btn-danger" /> |
-        <a asp-page="./Index">Back to List</a>
+
+        <div class="form-group space-btns">
+            <input type="submit" value="Delete" class="btn btn-danger" />
+            <a class="btn btn-secondary" href="/Positions/Details?positionid=@Model.JobPosition.Id">Cancel</a>
+        </div>
     </form>
+</div>
+
+<div>
+    <a asp-page="./Index">Back to List</a>
 </div>

--- a/Admin/Pages/Positions/Delete.cshtml.cs
+++ b/Admin/Pages/Positions/Delete.cshtml.cs
@@ -45,6 +45,10 @@ namespace Admin.Pages.Positions
             {
                 return NotFound();
             }
+            if (JobPosition.Active != 1)
+            {
+                return NotFound();
+            }
             if (saveChangesError.GetValueOrDefault())
             {
                 ErrorMessage = String.Format("Delete {ID} failed. Try again", id);
@@ -68,7 +72,6 @@ namespace Admin.Pages.Positions
             catch (DbUpdateException ex)
             {
                 _logger.LogError(ex, ErrorMessage);
-
                 return RedirectToAction("./Delete",
                                      new { id, saveChangesError = true });
             }

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -363,6 +363,19 @@ textarea.form-control {
   padding: 10px !important;
 }
 
+.margin-auto {
+  margin-left: auto !important;
+  margin-right: auto !important;
+}
+
+.small-margin-top {
+  margin-top: 25px;
+}
+
+.padding-left {
+  padding-left: 15px;
+}
+
 /* header {
   position: fixed !important;
   top: 0px;


### PR DESCRIPTION
Cancel buttons were added to most Create and Edit pages. However, I did not include the edit/create position page, as well as edit/create similar positions, because those pages will be part of another PR.

The changes to make inactive elements inaccessible (via the URL, mostly) applies to most cancel/edit/details pages, but the edit position and create/edit similar position pages have been excluded for now. 

In details/delete pages, I have made it so empty fields say "Not provided" instead of being blank (this change does not apply to the competency details/delete pages, but since the competency fields could potentially all be made required, it may not be necessary).

Also, the certificates/certificate description forms have been modified to use text areas instead of text inputs, that way, the user can see the entire text at once.

There are also very minor fixes, things like making page headers better (on delete pages, for instance), and setting the proper page title (in the tab on the browser). Additionally, I made it so the description fields are required when creating/editing a certificate description.

I made the competency level description fields read-only on the competency details page.

I added the competency type to the title of the edit page.