### PR TITLE
Added ability to copy a position. Other small fixes

### DIFF
--- a/Admin/Pages/Certificates/Descriptions/Index.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Index.cshtml
@@ -50,13 +50,13 @@
           <table class="table">
                 <thead>
                     <tr class="table-header-row text-center">
-                        <th><b class="sort-column">Certificate Description English</b></th>
-                        <th><b class="sort-column">Certificate Description French</b></th>
+                        <th><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate Description English</b></th>
+                        <th><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate Description French</b></th>
                         <th>
                             <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
-                            class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
+                            class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop"
                             aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
-                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                             title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
                         </th>
                     </tr>

--- a/Admin/Pages/Certificates/Index.cshtml
+++ b/Admin/Pages/Certificates/Index.cshtml
@@ -50,13 +50,13 @@
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">
-                    <th><b class="sort-column">Certificate English</b></th>
-                    <th><b class="sort-column">Certificate French</b></th>
+                    <th><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate English</b></th>
+                    <th><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate French</b></th>
                     <th>
                         <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
                         class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
                         aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
-                        alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page"
+                        alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                         title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
                     </th>
                 </tr>

--- a/Admin/Pages/Competencies/List.cshtml
+++ b/Admin/Pages/Competencies/List.cshtml
@@ -60,15 +60,15 @@
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">
-                    <th class="col-2"><b class="sort-column">Competency English</b></th>
-                    <th class="col-2"><b class="sort-column">Competency French</b></th>
-                    <th class="col-3"><b class="sort-column">Description English</b></th>
-                    <th class="col-4"><b class="sort-column">Description French</b></th>
+                    <th class="col-2"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Competency English</b></th>
+                    <th class="col-2"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Competency French</b></th>
+                    <th class="col-3"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Description English</b></th>
+                    <th class="col-4"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Description French</b></th>
                     <th class="col-1">
                         <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
                         class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
                         aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
-                        alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page"
+                        alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                         title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
                     </th>
                 </tr>

--- a/Admin/Pages/Positions/Details.cshtml
+++ b/Admin/Pages/Positions/Details.cshtml
@@ -95,14 +95,19 @@
                 </tr>
             }
 
-            <tr>
-                <th colspan="2" class="table-header-row"><span class="expand-elements-in-next-rows closed">CERTIFICATIONS / ATTESTATIONS</span></th>
-            </tr>
             @{
                 var certificates = Model.PositionCertificates.Where(e => e.Active == 1).OrderBy(x => x.NameEng.ToLower()).ToList();
             }
             @if (certificates.Any())
             {
+                <tr>
+                    <th colspan="2" class="table-header-row">
+                        <span class="expand-elements-in-next-rows closed" data-toggle="tooltip" title="Toggle expandable elements">
+                            CERTIFICATIONS / ATTESTATIONS
+                        </span>
+                    </th>
+                </tr>
+
                 @foreach (var certificate in certificates)
                 {
                     var key = "cert" + certificate.Id.ToString();
@@ -156,6 +161,9 @@
             else
             {
                 <tr>
+                    <th colspan="2" class="table-header-row"><span>CERTIFICATIONS / ATTESTATIONS</span></th>
+                </tr>
+                <tr>
                     <td colspan="2" class="bold">
                         This position does not have any certifications associated to it
                     </td>
@@ -173,12 +181,12 @@
                 int loopCounter = 0;
                 @foreach (var competencytype in Model.PositionCompetencyRatings)
                 {
-                    if (competencytype.Any(e => e.Active != 0))
+                    var competenciesOfType = competencytype.Where(e => e.Active != 0).OrderBy(x => x.CompetencyNameEng.ToLower()).ToList();
+                    if (competenciesOfType.Any())
                     {
-                        var competenciesOfType = competencytype.Where(e => e.Active != 0).OrderBy(x => x.CompetencyNameEng.ToLower()).ToList();
                         <tr>
-                            <th class="col-7 table-header-row"><span class="expand-elements-in-next-rows closed">@competencytype.FirstOrDefault()?.TypeNameEng.ToUpper() / @competencytype.FirstOrDefault()?.TypeNameFre.ToUpper()</span></th>
-                            <th class="text-center col-3 table-header-row"><span class="expand-elements-in-next-rows closed second-column">LEVEL / NIVEAU</span></th>
+                            <th class="col-7 table-header-row"><span class="expand-elements-in-next-rows closed" data-toggle="tooltip" title="Toggle expandable elements">@competencytype.FirstOrDefault()?.TypeNameEng.ToUpper() / @competencytype.FirstOrDefault()?.TypeNameFre.ToUpper()</span></th>
+                            <th class="text-center col-3 table-header-row"><span class="expand-elements-in-next-rows closed second-column" data-toggle="tooltip" title="Toggle expandable elements">LEVEL / NIVEAU</span></th>
                         </tr>
                         foreach (var c in competenciesOfType)
                         {
@@ -277,7 +285,12 @@
     </table>
 </div>
 
+<div class="form-group space-btns small-margin-top">
+    <a asp-page="./Edit" asp-route-id="@Model.Position.JobTitleId" class="btn btn-primary">Edit</a>
+    <a class="btn btn-info" href="/Positions/Create?id=@Model.Position.JobTitleId"
+    data-toggle="tooltip" title="Create a new position with the same details as current selection">Save a Copy</a>
+</div>
+
 <div>
-    <a asp-page="./Edit" asp-route-id="@Model.Position.JobTitleId">Edit</a> |
     <a asp-page="./Index">Back to List</a>
 </div>

--- a/Admin/Pages/Positions/Edit.cshtml
+++ b/Admin/Pages/Positions/Edit.cshtml
@@ -20,10 +20,11 @@
             <form method="post">
     
                 <partial name="_Position" model="Model" />
-
+                @* Create a new position with the same details as current selection*@
                 <div class="form-group space-btns">
                     <button class="btn btn-primary" asp-page-handler="create" asp-all-route-data="routedata">Save Changes</button>
-                    @*<a class="btn btn-info" href="/Positions/Index">Save a Copy</a>*@
+                    <a class="btn btn-info" href="/Positions/Create?id=@Model.Id"
+                    data-toggle="tooltip" title="Create a new position with the same details as current selection">Save a Copy</a>
                     <a class="btn btn-secondary" href="/Positions/Details?positionid=@Model.Id">Cancel</a>
                 </div>
             </form>

--- a/Admin/Pages/Positions/Index.cshtml
+++ b/Admin/Pages/Positions/Index.cshtml
@@ -47,14 +47,14 @@
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">
-                    <th width="7%"><b class="sort-column">Level</b></th>
-                    <th width="35%"><b class="sort-column">Title English</b></th>
-                    <th width="35%"><b class="sort-column">Title French</b></th>
+                    <th width="7%"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                    <th width="35%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                    <th width="35%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
                     <th width="15%">
                         <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
                         class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
                         aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
-                        alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page"
+                        alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                         title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
                     </th>
                 </tr>

--- a/Admin/Pages/Shared/_Competency.cshtml
+++ b/Admin/Pages/Shared/_Competency.cshtml
@@ -10,13 +10,39 @@
     <tr>
         <th colspan="3" class="table-header-row">
             <div class="row">
-                <div class="col-7 m-auto">
-                    <span class="@(atLeastOneCompetency ? "expand-elements-in-next-rows" : "") closed" id="@("tableTitle_" + Model.FullCompetencyNameOneWord)">@Model.FullCompetencyNameEng.ToUpper() / @Model.FullCompetencyNameFre.ToUpper()</span>
+                <div class="col-6 m-auto">
+                    @{
+                        if (atLeastOneCompetency)
+                        {
+                            <span class="expand-elements-in-next-rows closed" data-toggle="tooltip" title="Toggle expandable elements" id="@("tableTitle_" + Model.FullCompetencyNameOneWord)">
+                                @Model.FullCompetencyNameEng.ToUpper() / @Model.FullCompetencyNameFre.ToUpper()
+                            </span>
+                        }
+                        else
+                        {
+                            <span id="@("tableTitle_" + Model.FullCompetencyNameOneWord)">
+                                @Model.FullCompetencyNameEng.ToUpper() / @Model.FullCompetencyNameFre.ToUpper()
+                            </span>
+                        }
+                    }
                 </div>
                 <div class="col-3 text-center m-auto">
-                    <span class="@(atLeastOneCompetency ? "expand-elements-in-next-rows" : "") closed second-column" id="@("levelHeader_" + Model.FullCompetencyNameOneWord)">LEVEL / NIVEAU</span>
+                    @{
+                        if (atLeastOneCompetency)
+                        {
+                            <span class="expand-elements-in-next-rows closed second-column" data-toggle="tooltip" title="Toggle expandable elements" id="@("levelHeader_" + Model.FullCompetencyNameOneWord)">
+                                LEVEL / NIVEAU
+                            </span>
+                        }
+                        else
+                        {
+                            <span id="@("levelHeader_" + Model.FullCompetencyNameOneWord)">
+                                LEVEL / NIVEAU
+                            </span>
+                        }
+                    } 
                 </div>
-                <div class="col-2 text-right">
+                <div class="col-3 text-right">
                         @{
                             List<int> addedCompIds = new List<int>();
                             foreach (var comp in Model.AddedCompetenciesList.Where(x => x.Active == 1))
@@ -25,6 +51,63 @@
                             }
                             var remainingCompetenciesToAdd = Model.FullCompetencyList.Where(x => x.Active == 1 
                                 && !addedCompIds.Contains(x.Id)).Distinct();
+                        }
+                        @if (addedCompetencies.Count() > 1)
+                        {
+                            var routedataremoveall = new Dictionary<string, string> {
+                                {"id", FullPageModel.Id.ToString() },
+                                {"titleeng", FullPageModel.TitleEng },
+                                {"titlefre", FullPageModel.TitleFre },
+                                {"descriptioneng", FullPageModel.DescriptionEng },
+                                {"descriptionfre", FullPageModel.DescriptionFre },
+                                {"levelcode", FullPageModel.LevelCode },
+                                {"levelvalue", FullPageModel.LevelValue },
+                                {"regionids", FullPageModel.RegionIds },
+                                {"subjobgroupId", FullPageModel.SubJobGroupId.ToString() },
+                                {"jobgrouplevelid", FullPageModel.JobGroupLevelId.ToString() },
+                                {"jobgroupid", FullPageModel.JobGroupId.ToString() },
+                                {"jobhlcategory", FullPageModel.JobHLCategory },
+                                {"addedknowledgecompetencyids", FullPageModel.AddedKnowledgeCompetencyIds },
+                                {"addedtechnicalcompetencyids", FullPageModel.AddedTechnicalCompetencyIds },
+                                {"addedbehaviouralcompetencyids", FullPageModel.AddedBehaviouralCompetencyIds },
+                                {"addedexecutivecompetencyids", FullPageModel.AddedExecutiveCompetencyIds }
+                            };
+
+                            var strToRemoveFromDictionary = "added" + Model.FullCompetencyNameOneWord.ToLower() + "competencyids";
+                            routedataremoveall.Remove(strToRemoveFromDictionary);
+
+                            <button class="btn btn-danger remove-all-btn" type="button" 
+                                data-toggle="modal" data-target="#@("removeall-" + Model.FullCompetencyNameOneWord)">
+                                REMOVE ALL
+                            </button>
+
+                            <div class="modal fade bd-modal-xl" id="@("removeall-" + Model.FullCompetencyNameOneWord)" tabindex="-1" role="dialog" 
+                                aria-labelledby="@("removeall-" + Model.FullCompetencyNameOneWord + "ModelTitle")" aria-hidden="true">
+                                <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title" id="@("removeall-" + Model.FullCompetencyNameOneWord + "ModelTitle")">
+                                                REMOVE ALL @(Model.FullCompetencyNameEng.ToUpper())
+                                            </h5>
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div class="card-body text-center">
+                                                <h3 class="text-center">Are you sure you want to remove all @Model.FullCompetencyNameEng.ToLower() that have been added to this position?</h3>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                                                <button class="btn btn-primary resetWindowHeight" asp-page-handler="delete" 
+                                                    asp-all-route-data="@routedataremoveall">
+                                                    Yes
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
                         }
                         @if (remainingCompetenciesToAdd.Any())
                         {
@@ -92,12 +175,12 @@
                 
                 @foreach (var competency in addedCompetencies)
                 {
-                        var key1 = Model.ShortCompetencyName.ToLower().Substring(0, 2) + "_a_" + competency.CompetencyId.ToString();
-                        var key2 = Model.ShortCompetencyName.ToLower().Substring(0, 2) + "_b_" + competency.CompetencyId.ToString();
-                        var divKey = Model.ShortCompetencyName.ToLower() + "Div-" + competency.CompetencyId.ToString();
-                        var rateDivKey = Model.ShortCompetencyName.ToLower() + "RateDiv-" + competency.CompetencyId.ToString();
+                    var key1 = Model.ShortCompetencyName.ToLower().Substring(0, 2) + "_a_" + competency.CompetencyId.ToString();
+                    var key2 = Model.ShortCompetencyName.ToLower().Substring(0, 2) + "_b_" + competency.CompetencyId.ToString();
+                    var divKey = Model.ShortCompetencyName.ToLower() + "Div-" + competency.CompetencyId.ToString();
+                    var rateDivKey = Model.ShortCompetencyName.ToLower() + "RateDiv-" + competency.CompetencyId.ToString();
                     <div class="row">
-                        <div class="col-7">
+                        <div class="col-6">
                             <div class="accordion" id="@divKey">
                                 <button class="btn btn-link collapsed text-wrap text-left" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="@key1">
                                     @competency.CompetencyNameEng / @competency.CompetencyNameFre
@@ -180,7 +263,7 @@
                             </div>
                         </div>
 
-                        <div class="col-2 text-right">
+                        <div class="col-3 text-right">
                             @{
                                 var routedataremove = new Dictionary<string, string> {
                                     {"id", FullPageModel.Id.ToString() },
@@ -204,15 +287,14 @@
                             }
                             <button class="btn btn-link remove-btn resetWindowHeight" asp-page-handler="delete" asp-all-route-data="@routedataremove">REMOVE</button>
                         </div>
-                    </div>
-
+                    </div> 
                 }
             }
             else
             {
                 <div class="row">
                     <div class="col-9">
-                        <p class="no-competency">This position does not currently have any @Model.FullCompetencyNameOneWord.ToLower() competencies associated to it</p>
+                        <p class="no-competency">This position does not currently have any @Model.FullCompetencyNameEng.ToLower() associated to it</p>
                     </div>
                 </div>
             }

--- a/Admin/Pages/Shared/_Layout.cshtml
+++ b/Admin/Pages/Shared/_Layout.cshtml
@@ -17,7 +17,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3 no-padding">
             <div class="container">
-                <a class="navbar-brand" asp-area="" asp-page="/Index">CCG CCT Admin</a>
+                <a class="navbar-brand smooth-underline" asp-area="" asp-page="/Index">CCG CCT Admin</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
                     <span class="navbar-toggler-icon"></span>
@@ -25,22 +25,22 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item" id="navHome">
-                            <a class="nav-link text-dark" href="/Index">Home</a>
+                            <a class="nav-link" href="/Index">Home</a>
                         </li>
                         <li class="nav-item" id="navCertificates">
-                            <a class="nav-link text-dark" href="/Certificates">Certificates</a>
+                            <a class="nav-link" href="/Certificates">Certificates</a>
                         </li>
                         <li class="nav-item" id="navCertDesc">
-                            <a class="nav-link text-dark" href="/Certificates/Descriptions">Certificate Descriptions</a>
+                            <a class="nav-link" href="/Certificates/Descriptions">Certificate Descriptions</a>
                         </li>
                         <li class="nav-item" id="navPositions">
-                            <a class="nav-link text-dark" href="/Positions">Positions</a>
+                            <a class="nav-link" href="/Positions">Positions</a>
                         </li>
                         <li class="nav-item" id="navCompetencies">
-                            <a class="nav-link text-dark" href="/Competencies/List?typeid=1">Competencies</a>
+                            <a class="nav-link" href="/Competencies/List?typeid=1">Competencies</a>
                         </li>
                         <li class="nav-item" id="navSimilar">
-                            <a class="nav-link text-dark" href="/Similar">Similar Positions</a>
+                            <a class="nav-link" href="/Similar">Similar Positions</a>
                         </li>
                     </ul>
                 </div>

--- a/Admin/Pages/Shared/_Position.cshtml
+++ b/Admin/Pages/Shared/_Position.cshtml
@@ -117,7 +117,7 @@
 
         <tr>
             <td>
-                <label class="mr-3 no-highlight" for="allRegionsCheckbox">All Regions / Toutes les régions</label>
+                <label class="mr-3 no-highlight" for="allRegionsCheckbox" data-toggle="tooltip" title="Toggle all other checkboxes">All Regions / Toutes les régions</label>
             </td>
             @*  
                 Old code:    
@@ -304,7 +304,18 @@
             <th class="table-header-row">
                 <div class="row">
                     <div class="col-9 m-auto">
-                        <span class="@(atLeastOneCert ? "expand-elements-in-next-rows" : "") closed" id="certTableHeader">CERTIFICATIONS / ATTESTATIONS</span>
+                        @{
+                            if (atLeastOneCert)
+                            {
+                                <span class="expand-elements-in-next-rows closed" data-toggle="tooltip" title="Toggle expandable elements" id="certTableHeader">
+                                    CERTIFICATIONS / ATTESTATIONS
+                                </span>
+                            }
+                            else
+                            {
+                                <span id="certTableHeader">CERTIFICATIONS / ATTESTATIONS</span>
+                            }
+                        } 
                     </div>
                     <div class="col-3 text-right">
                         @{
@@ -316,9 +327,59 @@
                             var remainingCertificatesToAdd = Model.JobCertificates.Where(x => (x.Active == 1
                                 && !certIds.Contains(x.Id))).Distinct();
                         }
+                        @if (addedCertificates.Count() > 1)
+                        {
+                            var routedataremoveall = new Dictionary<string, string> {
+                                {"id", Model.Id.ToString() },
+                                {"titleeng", Model.TitleEng },
+                                {"titlefre", Model.TitleFre },
+                                {"descriptioneng", Model.DescriptionEng },
+                                {"descriptionfre", Model.DescriptionFre },
+                                {"levelcode", Model.LevelCode },
+                                {"levelvalue", Model.LevelValue },
+                                {"regionids", Model.RegionIds },
+                                {"subjobgroupId", Model.SubJobGroupId.ToString() },
+                                {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
+                                {"jobgroupid", Model.JobGroupId.ToString() },
+                                {"jobhlcategory", Model.JobHLCategory },
+                                {"addedknowledgecompetencyids", Model.AddedKnowledgeCompetencyIds },
+                                {"addedtechnicalcompetencyids", Model.AddedTechnicalCompetencyIds },
+                                {"addedbehaviouralcompetencyids", Model.AddedBehaviouralCompetencyIds },
+                                {"addedexecutivecompetencyids", Model.AddedExecutiveCompetencyIds }
+                            };
+                            <button class="btn btn-danger remove-all-btn resetWindowHeight" type="button" 
+                                data-toggle="modal" data-target="#removeallcerts">
+                                REMOVE ALL
+                            </button>
+
+                            <div class="modal fade bd-modal-xl" id="removeallcerts" tabindex="-1" role="dialog" aria-labelledby="removeAllCertsModalTitle" aria-hidden="true">
+                                <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
+                                    <div class="modal-content">
+                                        <div class="modal-header">
+                                            <h5 class="modal-title" id="removeAllCertsModalTitle">REMOVE ALL CERTIFICATES</h5>
+                                            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                <span aria-hidden="true">&times;</span>
+                                            </button>
+                                        </div>
+                                        <div class="modal-body">
+                                            <div class="card-body text-center">
+                                                <h3 class="text-center">Are you sure you want to remove all certificates that have been added to this position?</h3>
+                                            </div>
+                                            <div class="modal-footer">
+                                                <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                                                <button class="btn btn-primary resetWindowHeight" asp-page-handler="deletecertificate" 
+                                                    asp-all-route-data="@routedataremoveall">
+                                                    Yes
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                        }
                         @if (remainingCertificatesToAdd.Any())
                         {
-                            remainingCertificatesToAdd = remainingCertificatesToAdd.OrderBy(x => x.NameEng.ToLower());
+                            remainingCertificatesToAdd = remainingCertificatesToAdd.OrderBy(x => x.NameEng.ToLower()).ToList();
                             <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#addcert">
                                 Add
                             </button>
@@ -365,7 +426,14 @@
                                             }
                                             @foreach (var certificate in certDescs)
                                             {
-                                                <option value="@certificate.Id">@certificate.DescEng / @certificate.DescFre</option>
+                                                if (certificate.DescEng == "" && certificate.DescFre == "")
+                                                {
+                                                    <option value="@certificate.Id">No description</option>
+                                                }
+                                                else
+                                                {
+                                                    <option value="@certificate.Id">@certificate.DescEng / @certificate.DescFre</option>
+                                                }
                                             }
                                         </select>
                                     </div>
@@ -380,7 +448,7 @@
                 </div>
                 @if (atLeastOneCert)
                 {
-                    addedCertificates = addedCertificates.GroupBy(x => x.Id).Select(x => x.First()).ToList();
+                    addedCertificates = addedCertificates.GroupBy(x => x.Id).Select(x => x.First()).ToList(); // remove duplicates
 
                     @foreach (var certificate in addedCertificates)
                     {
@@ -395,37 +463,45 @@
                                     </button>
                                     <div id="@key1" class="collapse" aria-labelledby="#certTableHeader" data-parent="#@divKey">
                                         <div class="card-body">
-                                            @if (string.IsNullOrWhiteSpace(certificate.DescEng) && string.IsNullOrWhiteSpace(certificate.DescFre))
-                                            {
-                                                <p class="no-margins">
-                                                    <b>No description selected</b>
-                                                </p>
-                                                <div class="expanded-item-navigation">
-                                                    <a href="/Certificates/Edit?id=@certificate.Id" target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
-                                                        Edit Certificate <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
-                                                    </a>
-                                                    <hr />
-                                                </div>
+
+                                            @{
+                                                bool emptySelectedCertDesc = (certificate.DescEng == "" && certificate.DescFre == "");
                                             }
-                                            else
-                                            {
-                                                <p>
-                                                    <b>English Description</b><br />
-                                                    <span class="small-padding-top display-block">@(string.IsNullOrWhiteSpace(certificate.DescEng) ? "No description specified in English" : certificate.DescEng)</span>
-                                                </p>
-                                                <p>
-                                                    <b>French Description</b><br />
-                                                    <span class="small-padding-top display-block">@(string.IsNullOrWhiteSpace(certificate.DescFre) ? "Aucune description specifée en français" : certificate.DescFre)</span>
-                                                </p>
-                                                <div class="expanded-item-navigation">
-                                                    <a href="/Certificates/Edit?id=@certificate.Id" target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
-                                                        Edit Certificate <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
-                                                    </a> <span class="small-padding-left">|</span>
-                                                    <a href="/Certificates/Descriptions/Edit?id=@certificate.CertificateDescId" target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
-                                                        Edit Certificate Description <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
-                                                    <hr />
-                                                </div>
-                                            }
+                                            <select class="form-control dropdown-toggle mrgn-bttm-md cert-desc-dropdown 
+                                                @(emptySelectedCertDesc ? "bold" : "")" id="cert-desc-@certificate.Id">
+                                                @foreach (var desc in certDescs)
+                                                {
+                                                    bool emptyDescInDropdown = (desc.DescEng == "" && desc.DescFre == "");
+                                                    if (certificate.DescEng.ToLower() == desc.DescEng.ToLower())
+                                                    {
+                                                        <option selected value="@desc.Id" class="@(emptyDescInDropdown ? "bold" : "")">
+                                                            @(emptyDescInDropdown ? "No description" : desc.DescEng + " / " + desc.DescFre)
+                                                        </option>
+                                                    }
+                                                    else
+                                                    {
+                                                        <option value="@desc.Id" class="@(emptyDescInDropdown ? "bold" : "")">
+                                                            @(emptyDescInDropdown ? "No description" : desc.DescEng + " / " + desc.DescFre)
+                                                        </option>
+                                                    }
+                                                }
+                                            </select>
+
+                                            <div class="expanded-item-navigation">
+                                                <a href="/Certificates/Edit?id=@certificate.Id" target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
+                                                    Edit Certificate <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                                </a> 
+                                                <span class="small-padding-left vertical-bar-cert-desc @(emptySelectedCertDesc ? "dontShow" : "")">|</span>
+                                                <a class="cert-desc-link @(emptySelectedCertDesc ? "dontShow" : "")" 
+                                                    href="/Certificates/Descriptions/Edit?id=@certificate.CertificateDescId" 
+                                                    target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
+                                                    Edit Certificate Description
+                                                        <img src="~/images/icons/external_link_icon.png" 
+                                                        class="external-link" alt="Open link in new tab" />
+                                                </a>
+                                                <hr />
+                                            </div>
+
                                         </div>
                                     </div>
                                 </div>
@@ -435,14 +511,14 @@
                                 @{
                                     var routedataremove = new Dictionary<string, string> {
                                         {"id", Model.Id.ToString() },
-                                        {"titleeng",Model.TitleEng },
-                                        {"titlefre",Model.TitleFre },
-                                        {"descriptioneng",Model.DescriptionEng },
-                                        {"descriptionfre",Model.DescriptionFre },
+                                        {"titleeng", Model.TitleEng },
+                                        {"titlefre", Model.TitleFre },
+                                        {"descriptioneng", Model.DescriptionEng },
+                                        {"descriptionfre", Model.DescriptionFre },
                                         {"levelcode", Model.LevelCode },
                                         {"levelvalue", Model.LevelValue },
                                         {"regionids", Model.RegionIds },
-                                        {"subjobgroupId" , Model.SubJobGroupId.ToString() },
+                                        {"subjobgroupId", Model.SubJobGroupId.ToString() },
                                         {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
                                         {"jobgroupid", Model.JobGroupId.ToString() },
                                         {"jobhlcategory", Model.JobHLCategory },

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -90,6 +90,7 @@ body {
     --btnPrimary: #0069d9;
     --btnSecondaryColour: #5a6268;
     --btnDangerColour: #dc3545;
+    --lightBlue: rgb(108, 213, 254);
     /* --scrollbarTrack: #2e3338; */
     --tableHeaderBgColour: #f2f2f2;
     --scrollbarTrack: #5a6268;
@@ -185,8 +186,13 @@ h4.no-results {
     user-select: none;
 }
 
+.expand-all-children:hover, .expand-elements-in-next-rows:hover {
+    opacity: 0.8;
+}
+
 .remove-btn {
     color: red;
+    font-weight: bold;
 }
 
     .remove-btn:hover {
@@ -242,7 +248,7 @@ h4.no-results {
         #table-container table thead {
             position: sticky;
             top: 0px;
-            z-index: 300000 !important;
+            z-index: 100 !important;
             background-color: white;
         }
 
@@ -320,6 +326,7 @@ textarea.form-control {
     display: inline !important;
     width: fit-content;
     margin: 5px 10px;
+    user-select: none;
 }
 
 .dontShow, *.dontShow {
@@ -392,6 +399,23 @@ textarea.form-control {
     padding-bottom: 6px;
 }
 
+.navbar-nav {
+    user-select: none !important;
+}
+
+.navbar-light .navbar-nav .nav-item a.nav-link {
+    opacity: 1;
+    color: rgba(0, 0, 0, 1);
+}
+
+.nav-item.selected .nav-link {
+    cursor: default !important;
+}
+
+.nav-item:not(.selected) .nav-link:hover, .navbar-brand:hover, .nav-item:not(.selected) .nav-link:active, .navbar-brand:active {
+    color: var(--btnPrimary) !important;
+}
+
     .nav-item:not(.selected) .nav-link::after, .smooth-underline::after {
         content: '';
         display: block;
@@ -409,7 +433,7 @@ textarea.form-control {
     }
 
 .smooth-underline::after {
-    background-color: black !important;
+    background-color: var(--btnPrimary) !important;
     opacity: 0 !important;
     transition: opacity 0.15s, transform 0.15s !important;
     transform: scale(0) !important;
@@ -507,13 +531,13 @@ a:hover .external-link {
 }
 
 .glyphicon-save-file:before {
-    content:"\e202";
+    content: "\e202";
 }
 
 .glyphicon {
     font-size: 35px;
-    background:#fff;
-    border-radius:999px;
+    background: #fff;
+    border-radius: 999px;
     position: relative;
     top: 15px;
 }
@@ -521,6 +545,19 @@ a:hover .external-link {
 .glyphicon:hover {
     cursor: pointer;
     opacity: 0.7;
+}
+
+.remove-all-btn {
+    margin-right: 5px;
+    font-weight: bold;
+}
+
+.bottom-two-px {
+    top: -2px !important;
+}
+
+.no-margin-bottom {
+    margin-bottom: 0px !important;
 }
 
 @media print {


### PR DESCRIPTION
**Full list of changes:**

-"Save a Copy" feature for position: from a position's details or edit page, you can now click on the new "Save a Copy" button, which will bring the user to the Create position page, which will already be filled with the information of the position copied (everything except the title). At that point, the user simply has to give the position a new title, and do any changes that may be required. The "Save a Copy" button also comes with a tooltip to indicate its use

-Added a "Remove all" button for competencies and certificates. Brings up a modal window asking for confirmation, and if the user confirms, the corresponding elements are removed (as one would expect)

-Made it so users can change a certificate description without removing and adding the certificate again in position edit/create, by selecting the desired description in a dropdown

**Small fixes:**

-Added the sorted icon to the default sorted column on index pages (previously, it would only appear once the user actively sorted a column)

-Added a tooltip on the arrow icon on index pages that allows for collapsing/expanding the top of the page

-Added a tooltip to indicate that the columns can be sorted (note, the previous three changes do not yet apply to the similar positions index page, that will come in the next PR)

-Added a tooltip for expanding/collapsing elements in position create/edit/details pages by using the table headers

-Fixed a bug in position details that would display the "Certificates" header once for each certificate to display

-Small styling changes, most notably bolding the "REMOVE" button next to competencies and certificates (or similar positions that have been added), and also changing the styling for when a navigation element is hovered

-Note: most of the site.js changes will apply to the next PR, but some of them are needed in this one