### PR TITLE
Added ability to copy similar positions

### DIFF
--- a/Admin/Data/PartialModels/SimilarEdit.cs
+++ b/Admin/Data/PartialModels/SimilarEdit.cs
@@ -65,5 +65,9 @@ namespace Admin.Data.PartialModels
 
         public JobPositionDto CurrentSelectedPosition { get; set; }
 
+        public bool CopyingAPosition { get; set; } = false;
+
+        public bool HadSimilarPositionsOnLoadingPage { get; set; } = false;
+
     }
 }

--- a/Admin/Pages/Shared/_LayoutNoNavigation.cshtml
+++ b/Admin/Pages/Shared/_LayoutNoNavigation.cshtml
@@ -20,6 +20,12 @@
         </main>
     </div>
 
+    <footer class="border-top footer text-muted">
+        <div class="container">
+            &copy; @DateTime.Now.Year - Canadian Coast Guard Career Competency Tool | Admin
+        </div>
+    </footer>
+
     @*<script src="https://cdnjs.cloudflare.com/ajax/libs/popper.js/1.12.9/umd/popper.min.js"></script>*@
     <script src="https://code.jquery.com/jquery-3.3.1.slim.min.js" integrity="sha384-q8i/X+965DzO0rT7abK41JStQIAqVgRVzpbzo5smXKp4YfRvH+8abtTE1Pi6jizo" crossorigin="anonymous"></script>
     <script src="https://cdn.jsdelivr.net/npm/popper.js@1.14.6/dist/umd/popper.min.js" integrity="sha384-wHAiFfRlMFy6i5SRaxvfOCifBUQy1xHdJ/yoi7FRNXMRBu5WHdZYu1hA6ZOblgut" crossorigin="anonymous"></script>

--- a/Admin/Pages/Shared/_SimilarDetails.cshtml
+++ b/Admin/Pages/Shared/_SimilarDetails.cshtml
@@ -23,7 +23,8 @@
                 </tr>
             </tbody>
         </table>
-        <table class="table table-bordered">
+
+        <table class="table table-bordered no-margin-bottom">
             <thead>
                 <tr>
                     @{
@@ -59,7 +60,9 @@
                                 <div class="row">
                                     <div class="col-12 @(position.JobTitleId == Model.JobPositionId ? "same-position" : "")">
                                         <a class="btn btn-link col-12 text-left text-wrap" href="/Positions/Details?positionid=@position.JobTitleId">
-                                                @position.JobGroupLevelCode @position.JobTitleEng / @position.JobTitleFre 
+                                                @position.JobGroupLevelCode @position.JobTitleEng 
+                                                <span class="bold @(position.JobTitleId == Model.JobPositionId ? "text-dark" : "")">/</span> 
+                                                @position.JobTitleFre 
                                         </a>
                                         <hr />
                                     </div>

--- a/Admin/Pages/Shared/_SimilarEdit.cshtml
+++ b/Admin/Pages/Shared/_SimilarEdit.cshtml
@@ -38,6 +38,8 @@
         }
     }
 
+    var allActiveJobs = Model.AllActiveJobs;
+
     var allJobsThatCanBeAdded = new List<JobPositionDto>();
 
     var groupLevelCodesWithAtLeastOneJob = new List<string>();
@@ -52,7 +54,6 @@
     var actualSelectedJobGroupLevel = new JobGroupPositionDto();
 
     int intValue;
-    var allActiveJobs = Model.AllActiveJobs;
 
     foreach (var job in allActiveJobs)
     {
@@ -62,7 +63,7 @@
         // because levels that have no jobs to that can be added can't be selected. This loop does the same thing for
         // groups (example, AS), to identify which ones have at least one job that can be added
 
-        if (!allAddedSimilarJobsIds.TryGetValue(job.JobTitleId, out intValue)) // this makes sure you can't add the same position twice
+        if (!allAddedSimilarJobsIds.TryGetValue(job.JobTitleId, out intValue)) // we are only retrieving the jobs that have NOT been added yet
         {
             jobGroupCodesWithAtLeastOneJob.Add(job.JobGroupCode.ToUpper());
             allJobsThatCanBeAdded.Add(job);
@@ -248,7 +249,8 @@
                                                     {"AddedSeventyPercentIds", Model.SeventyPercentIds },
                                                     {"subjobgroupId" , Model.SubJobGroupId.ToString() },
                                                     {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
-                                                    {"jobgroupid",jobgroup.Id.ToString() }
+                                                    {"jobgroupid",jobgroup.Id.ToString() },
+                                                    {"copyingaposition", Model.CopyingAPosition.ToString() }
                                                 };
 
                                                 <li>
@@ -303,7 +305,8 @@
                                                     {"levelcode", level.LevelCode },
                                                     {"subgroupcode", level.SubGroupCode },
                                                     {"subjobgroupId" , Model.SubJobGroupId.ToString() },
-                                                    {"jobgrouplevelid", Model.JobGroupLevelId.ToString() }
+                                                    {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
+                                                    {"copyingaposition", Model.CopyingAPosition.ToString() }
                                                 };
 
                                                 <li role="presentation">
@@ -385,24 +388,124 @@
                     </tr>
                 </tbody>
             </table>
-            <table class="table table-bordered small-margin-top">
+
+            @{
+                var positionList = Model.JobPositions
+                    .Where(e => e.Active != 0)
+                    .OrderBy(x => x.JobTitleEng.ToLower())
+                    .OrderBy(x => x.JobGroupLevelCode.ToLower())
+                    .ToList()
+                    .GroupBy(x => x.JobTitleId)
+                    .Select(x => x.First())
+                    .ToList();
+            }
+
+            <table class="table table-bordered small-margin-top no-margin-bottom">
                 <thead>
                     <tr>
-                        <th class="table-header-row">SIMILAR POSITIONS</th>
+                        <th class="table-header-row">
+                            <div class="row">
+                                <div class="col-6 m-auto">
+                                    SIMILAR POSITIONS
+                                </div>
+                                <div class="col-6 text-right">
+                                    @if (positionList.Count() > 1)
+                                    {
+                                        var routedataremoveall = new Dictionary<string, string> {
+                                            {"id", Model.JobPositionId.ToString() },
+                                            {"levelvalue", Model.LevelValue },
+                                            {"jobgroupid", actualSelectedJobGroup.Id.ToString() },
+                                            {"levelcode", actualSelectedJobGroupLevel.LevelCode },
+                                            {"AddedOneHundredPercentIds", Model.OneHundredPercentIds },
+                                            {"AddedNinetyPercentIds", Model.NinetyPercentIds },
+                                            {"AddedEightyPercentIds", Model.EightyPercentIds },
+                                            {"AddedSeventyPercentIds", Model.SeventyPercentIds },
+                                            {"subgroupcode", Model.SubGroupCode },
+                                            {"subjobgroupId" , Model.SubJobGroupId.ToString() },
+                                            {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
+                                            {"copyingaposition", Model.CopyingAPosition.ToString() }
+                                        };
+
+                                        switch (Model.PercentMatch) {
+                                             case 100:
+                                                routedataremoveall.Remove("AddedOneHundredPercentIds");
+                                                break;
+                                            case 90:
+                                                routedataremoveall.Remove("AddedNinetyPercentIds");
+                                                break;
+                                            case 80:
+                                                routedataremoveall.Remove("AddedEightyPercentIds");
+                                                break;
+                                            case 70:
+                                                routedataremoveall.Remove("AddedSeventyPercentIds");
+                                                break;
+                                        }
+
+                                        <button class="btn btn-danger remove-all-btn" type="button" 
+                                            data-toggle="modal" data-target="#removeallsimilar">
+                                            REMOVE ALL
+                                        </button>
+
+                                        <div class="modal fade bd-modal-xl" id="removeallsimilar" tabindex="-1" role="dialog" 
+                                            aria-labelledby="removeallsimilarModalTitle" aria-hidden="true">
+                                            <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
+                                                <div class="modal-content">
+                                                    <div class="modal-header">
+                                                        <h5 class="modal-title" id="removeallsimilarModalTitle">
+                                                            REMOVE ALL POSITIONS AT @Model.PercentMatch.ToString()% MATCH
+                                                        </h5>
+                                                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                                                            <span aria-hidden="true">&times;</span>
+                                                        </button>
+                                                    </div>
+                                                    <div class="modal-body">
+                                                        <div class="card-body text-center">
+                                                            <h3 class="text-center">Are you sure you want to remove all similar positions added at @Model.PercentMatch.ToString()% match?</h3>
+                                                        </div>
+                                                        <div class="modal-footer">
+                                                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                                                            @if (Model.PercentMatch == 100)
+                                                            {
+                                                                <button class="btn btn-primary resetWindowHeight" asp-page-handler="deleteonehundredpercentsimilarposition" 
+                                                                    asp-all-route-data="@routedataremoveall">
+                                                                    Yes
+                                                                </button>
+                                                            }
+                                                            else if (Model.PercentMatch == 90)
+                                                            {
+                                                                <button class="btn btn-primary resetWindowHeight" asp-page-handler="deleteninetypercentsimilarposition" 
+                                                                    asp-all-route-data="@routedataremoveall">
+                                                                    Yes
+                                                                </button>
+                                                            }
+                                                            else if (Model.PercentMatch == 80)
+                                                            {
+                                                                <button class="btn btn-primary resetWindowHeight" asp-page-handler="deleteeightypercentsimilarposition" 
+                                                                    asp-all-route-data="@routedataremoveall">
+                                                                    Yes
+                                                                </button>
+                                                            }
+                                                            else if (Model.PercentMatch == 70)
+                                                            {
+                                                                <button class="btn btn-primary resetWindowHeight" asp-page-handler="deleteseventypercentsimilarposition" 
+                                                                    asp-all-route-data="@routedataremoveall">
+                                                                    Yes
+                                                                </button>
+                                                            }
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    }
+                                </div>
+                            </div>
+                        </th>
                     </tr>
                 </thead>
                 <tbody>
                     <tr>
                         <td>
-
-                            @{
-                                var positionList = Model.JobPositions
-                                    .Where(e => e.Active != 0)
-                                    .OrderBy(x => x.JobTitleEng.ToLower())
-                                    .OrderBy(x => x.JobGroupLevelCode.ToLower())
-                                    .ToList();
-                            }
-
                             @if (positionList.Any())
                             {
 
@@ -432,38 +535,41 @@
                                         {"AddedSeventyPercentIds", Model.SeventyPercentIds },
                                         {"subgroupcode", Model.SubGroupCode },
                                         {"subjobgroupId" , Model.SubJobGroupId.ToString() },
-                                        {"jobgrouplevelid", Model.JobGroupLevelId.ToString() }
+                                        {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
+                                        {"copyingaposition", Model.CopyingAPosition.ToString() }
                                     };
 
                                     <div class="row">
                                         <div class="col-10 @(position.JobTitleId == Model.JobPositionId ? "same-position" : "")">
                                             <a target="_blank" class="btn btn-link text-left text-wrap" href="/Positions/Details?positionid=@position.JobTitleId">
-                                                @position.JobGroupLevelCode @position.JobTitleEng / @position.JobTitleFre 
+                                                @position.JobGroupLevelCode @position.JobTitleEng 
+                                                <span class="bold @(position.JobTitleId == Model.JobPositionId ? "text-dark" : "")">/</span> 
+                                                @position.JobTitleFre 
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
                                         </div>
-                                        <div class="col-2">
+                                        <div class="col-2 text-right">
                                             @if (Model.PercentMatch == 100)
                                             {
-                                                <button class="btn btn-link remove-btn resetWindowHeight text-center display-block margin-auto" asp-page-handler="deleteonehundredpercentsimilarposition" asp-all-route-data="@routedataremove">
+                                                <button class="btn btn-link remove-btn resetWindowHeight" asp-page-handler="deleteonehundredpercentsimilarposition" asp-all-route-data="@routedataremove">
                                                     REMOVE
                                                 </button>
                                             }
                                             else if (Model.PercentMatch == 90)
                                             {
-                                                <button class="btn btn-link remove-btn resetWindowHeight text-center display-block margin-auto" asp-page-handler="deleteninetypercentsimilarposition" asp-all-route-data="@routedataremove">
+                                                <button class="btn btn-link remove-btn resetWindowHeight" asp-page-handler="deleteninetypercentsimilarposition" asp-all-route-data="@routedataremove">
                                                     REMOVE
                                                 </button>
                                             }
                                             else if (Model.PercentMatch == 80)
                                             {
-                                                <button class="btn btn-link remove-btn resetWindowHeight text-center display-block margin-auto" asp-page-handler="deleteeightypercentsimilarposition" asp-all-route-data="@routedataremove">
+                                                <button class="btn btn-link remove-btn resetWindowHeight" asp-page-handler="deleteeightypercentsimilarposition" asp-all-route-data="@routedataremove">
                                                     REMOVE
                                                 </button>
                                             }
                                             else if (Model.PercentMatch == 70)
                                             {
-                                                <button class="btn btn-link remove-btn resetWindowHeight text-center display-block margin-auto" asp-page-handler="deleteseventypercentsimilarposition" asp-all-route-data="@routedataremove">
+                                                <button class="btn btn-link remove-btn resetWindowHeight" asp-page-handler="deleteseventypercentsimilarposition" asp-all-route-data="@routedataremove">
                                                     REMOVE
                                                 </button>
                                             }
@@ -483,24 +589,21 @@
                 </tbody>
             </table>
 
-            @if (Model.IsInEditMode)
-            {
-                <div class="form-group space-btns">
-                    <button class="btn btn-primary" asp-page-handler="edit" asp-all-route-data="@routedataadd">
-                        Save Changes
-                    </button>
-                    <a class="btn btn-secondary" href="/Similar/Details?id=@Model.JobPositionId">Cancel</a>
-                </div>
-            }
-            else
-            {
-                <div class="form-group space-btns">
-                    <button class="btn btn-primary" asp-page-handler="edit" asp-all-route-data="@routedataadd">
-                        Create
-                    </button>
-                    <a class="btn btn-secondary" href="/Similar">Cancel</a>
-                </div>
-            }
+            <div class="form-group space-btns small-margin-top">
+                <button class="btn btn-primary" asp-page-handler="edit" asp-all-route-data="@routedataadd">
+                    Save Changes
+                </button>
+                @if (Model.HadSimilarPositionsOnLoadingPage && Model.IsInEditMode && !Model.CopyingAPosition)
+                {
+                    <a class="btn btn-info" href="/Similar?copyid=@Model.JobPositionId"
+                        data-toggle="tooltip" title="Applies these similar positions to another position of your choice">
+                        Copy Similar Positions
+                    </a>
+                }
+                <a class="btn btn-secondary" href="@(Model.IsInEditMode ? "/Similar/Details?id=" + Model.JobPositionId : "/Similar")">
+                    Cancel
+                </a>
+            </div>
         </form>
     </div>
 </div>

--- a/Admin/Pages/Similar/Create.cshtml
+++ b/Admin/Pages/Similar/Create.cshtml
@@ -17,7 +17,8 @@
         {"selectedjobpositionid",Model.SelectedJobPositionId.ToString() },
         {"subgroupcode", Model.SubGroupCode },
         {"subjobgroupId" , Model.SubJobGroupId.ToString() },
-        {"jobgrouplevelid", Model.JobGroupLevelId.ToString() }
+        {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
+        {"copyingaposition", Model.CopyingAPosition.ToString() }
     };
     
     var createModel = new SimilarEditPartialModel
@@ -41,11 +42,19 @@
         CurrentSelectedLevelCode = Model.LevelCode,
         CurrentSelectedPosition = Model.CurrentSelectedPosition,
         CreateModel = Model,
-        IsInEditMode = false
+        IsInEditMode = false,
+        CopyingAPosition = Model.CopyingAPosition
     };
 }
 
-<h1>Create Similar Positions</h1>
+@if (Model.CopyingAPosition)
+{
+    <h1>Applying Similar Positions</h1>
+}
+else
+{
+    <h1>Create Similar Positions</h1>   
+}
 
 <h4>Current Position: <a target="_blank" href="/Positions/Details?positionid=@Model.CurrentPosition.JobTitleId">@Model.CurrentPosition.JobGroupLevelCode @Model.CurrentPosition.JobTitleEng
     <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a></h4>
@@ -53,6 +62,14 @@
 <h4 class="medium-margin-top small-margin-bottom">Position actuelle: <a target="_blank" href="/Positions/Details?positionid=@Model.CurrentPosition.JobTitleId">
     @Model.CurrentPosition.JobGroupLevelCode @Model.CurrentPosition.JobTitleFre
     <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a></h4>
+
+@if (Model.CopyingAPosition)
+{
+    <div class="alert alert-primary" role="alert">
+        Note: in order for the similar positions copied to be applied, you must click on the "Save Changes" button. 
+        <b>Doing so will overwrite any previously saved similar positions</b>
+    </div>
+}
 
 <hr />
 

--- a/Admin/Pages/Similar/Details.cshtml
+++ b/Admin/Pages/Similar/Details.cshtml
@@ -10,7 +10,7 @@
     // The model is in Admin/Data/PartialModels (the models used for partial views)
     var detailsModel = new SimilarDetailsPartialModel
     {
-        JobPositionId = Model.CurrentPosition.JobTitleId,
+        JobPositionId = Model.CurrentPosition.JobTitleId
     };
 }
 
@@ -45,8 +45,22 @@ else if (Model.PercentSelection == "70")
     <partial name="_SimilarDetails" model="@detailsModel" />
 }
 
-<div>
-    <a asp-page="./Edit" asp-route-id="@Model.CurrentPosition.JobTitleId">Edit</a> |
+@if (Model.HasMultipleSimilarPositions)
+{
+    <div class="form-group space-btns small-margin-top">
+        <a asp-page="./Edit" asp-route-id="@Model.CurrentPosition.JobTitleId" class="btn btn-primary">Edit</a>
+        <a class="btn btn-info" href="/Similar?copyid=@Model.CurrentPosition.JobTitleId"
+            data-toggle="tooltip" title="Applies these similar positions to another position of your choice">
+            Copy Similar Positions
+        </a>
+    </div>
+}
+
+<div class="@(!Model.HasMultipleSimilarPositions ? "small-margin-top" : "")">
+    @if (!Model.HasMultipleSimilarPositions)
+    {
+        <a href="/Similar/Edit?id=@Model.CurrentPosition.JobTitleId">Edit</a> <span>|</span>
+    }
     <a asp-page="./Index">Back to List</a>
 </div>
 

--- a/Admin/Pages/Similar/Edit.cshtml
+++ b/Admin/Pages/Similar/Edit.cshtml
@@ -39,7 +39,8 @@
         AllActiveJobs = await Model.GetAllActiveJobs(),
         CurrentSelectedLevelCode = Model.LevelCode,
         CurrentSelectedPosition = Model.CurrentSelectedPosition,
-        EditModel = Model
+        EditModel = Model,
+        HadSimilarPositionsOnLoadingPage = await Model.HasSimilarPositionsOnLoadingPage(Model.Id)
     };
 }
 

--- a/Admin/Pages/Similar/ExecutiveSummary.cshtml
+++ b/Admin/Pages/Similar/ExecutiveSummary.cshtml
@@ -12,7 +12,7 @@
 
 <br /><br />
 
-<span class="glyphicon glyphicon-save-file pull-right" onclick="print()"></span>
+<span class="glyphicon glyphicon-save-file relatively-down pull-right" onclick="print()"></span>
 
 <h1>Number of Similar Positions Per Percentage</h1>
 
@@ -26,8 +26,10 @@
             <th style="width: 33.33%;"><b class="sort-column-percents">Title English</b></th>
             <th style="width: 33.33%;"><b class="sort-column-percents">Title French</b></th>
             <th style="width: 25%;">
-                <div class="four-col-grid"><span class="sort-column-percents">100%</span>
-                    <span class="sort-column-percents">90%</span><span class="sort-column-percents">80%</span>
+                <div class="four-col-grid">
+                    <span class="sort-column-percents">100%</span>
+                    <span class="sort-column-percents">90%</span>
+                    <span class="sort-column-percents">80%</span>
                     <span class="sort-column-percents">70%</span>
                 </div>
             </th>

--- a/Admin/Pages/Similar/Index.cshtml
+++ b/Admin/Pages/Similar/Index.cshtml
@@ -6,10 +6,27 @@
 }
 
 <div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
-    <h1>Similar Positions</h1>
-    <p>
-        <a class="btn btn-dark" target="_blank" asp-page="ExecutiveSummary">Print Executive Summary</a>
-    </p>
+    @if (Model.CopyingAPosition)
+    {
+        <h4 class="small-margin-bottom">Copying Similar Positions From: 
+            <a target="_blank" href="/Positions/Details?positionid=@Model.PositionBeingCopied.JobTitleId" data-toggle="tooltip"
+                title="@Model.PositionBeingCopied.JobGroupLevelCode @Model.PositionBeingCopied.JobTitleFre">
+                @Model.PositionBeingCopied.JobGroupLevelCode @Model.PositionBeingCopied.JobTitleEng
+                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+            </a>
+        </h4>
+    }
+    else
+    {
+        <h1>Similar Positions</h1>
+    }
+    @if (!Model.CopyingAPosition)
+    {
+        <p>
+            <a class="btn btn-dark" target="_blank" asp-page="ExecutiveSummary">View / Print List</a>
+            <a class="btn btn-secondary pull-right bold" asp-page="Locate">Locate Positions</a>
+        </p> 
+    }
 
     @{
         string? filterValue = Model.Filter;
@@ -33,18 +50,37 @@
             <h6>
                 <label for="Filter">Find positions:</label>
                 <input type="text" asp-for="@Model.Filter" />
+
+                @if (Model.CopyingAPosition)
+                {
+                    <input name="copyid" type="hidden" value="@Model.PositionBeingCopied.JobTitleId" />
+                }
+
                 <input type="submit" value="Search" class="btn btn-primary" /> 
                 @if (!String.IsNullOrWhiteSpace(Model.Filter))
                 {
-                    <span><span class="vertical-bar">|</span> <a href="/Similar">Back to Full List</a></span>
+                    <span><span class="vertical-bar">|</span> 
+                        <a href="@("/Similar" + (Model.CopyingAPosition ? "?copyid=" + @Model.PositionBeingCopied.JobTitleId : ""))">
+                            Back to Full List
+                        </a>
+                    </span>
                 }
-                @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
+                @if (!Model.CopyingAPosition)
                 {
-                    <a class="pull-right" href="/Similar?numMatching=false&filter=@filterValue">Hide Number of Matching Positions Per Percentage</a>
+                    @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
+                    {
+                        <a class="pull-right" href="/Similar?numMatching=false&filter=@filterValue">Hide Number of Matching Positions Per Percentage</a>
+                    }
+                    else
+                    {
+                        <a class="pull-right" href="/Similar?numMatching=true&filter=@filterValue">View Number of Matching Positions Per Percentage</a>
+                    }
                 }
                 else
                 {
-                    <a class="pull-right" href="/Similar?numMatching=true&filter=@filterValue">View Number of Matching Positions Per Percentage</a>
+                    <a class="btn btn-danger pull-right bottom-two-px bold" href="/Similar/Details?id=@Model.PositionBeingCopied.JobTitleId">
+                        Cancel Copy
+                    </a>
                 }
             </h6>
         </div>
@@ -59,29 +95,35 @@
                 <tr class="table-header-row text-center">
                     @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
                     {
-                        <th class="col-1"><b class="sort-column-percents">Level</b></th>
-                        <th class="col-3"><b class="sort-column-percents">Title English</b></th>
-                        <th class="col-3"><b class="sort-column-percents">Title French</b></th>
-                        <th class="col-3"><div class="four-col-grid"><span class="sort-column-percents">100%</span>
-                            <span class="sort-column-percents">90%</span><span class="sort-column-percents">80%</span>
-                            <span class="sort-column-percents">70%</span></div></th>
+                        <th class="col-1"><b class="sort-column-percents sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                        <th class="col-3"><b class="sort-column-percents" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                        <th class="col-3"><b class="sort-column-percents" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
+                        <th class="col-3">
+                            <div class="four-col-grid">
+                                <span class="sort-column-percents" data-toggle="tooltip" title="Click to sort column">100%</span>
+                                <span class="sort-column-percents" data-toggle="tooltip" title="Click to sort column">90%</span>
+                                <span class="sort-column-percents" data-toggle="tooltip" title="Click to sort column">80%</span>
+                                <span class="sort-column-percents" data-toggle="tooltip" title="Click to sort column">70%</span>
+                            </div>
+                        </th>
                         <th class="col-2">
                             <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
                             class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
                             aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
-                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
                         </th>
                     }
                     else
                     {
-                        <th class="col-1"><b class="sort-column">Level</b></th>
-                        <th class="col-4"><b class="sort-column">Title English</b></th>
-                        <th class="col-5"><b class="sort-column">Title French</b></th>
+                        <th class="col-1"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                        <th class="col-4"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                        <th class="col-5"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
                         <th class="col-2">
                             <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
                             class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
                             aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
-                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page"
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                             title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
                         </th>
                     }
@@ -109,6 +151,8 @@
                 }
                 @foreach (var item in itemsList)
                 {
+                    bool positionHasSimilarOnes = false;
+
                     <tr>
                         <td class="text-center sort-percents">
                             @Html.DisplayFor(modelItem => item.LevelCode)
@@ -124,31 +168,95 @@
                             <td class="four-col-grid">
                                 @{
                                     foreach (var positionCount in 
-                                                Model.NumberOfMatchingPositionsPerPecrentagePerPosition[item.JobTitleId].Split("&"))
+                                        Model.NumberOfMatchingPositionsPerPecrentagePerPosition[item.JobTitleId].Split("&"))
                                     {
+                                        if (!positionHasSimilarOnes)
+                                        {
+                                            int result;
+                                            if (int.TryParse(positionCount, out result))
+                                            {
+                                                if (result > 0)
+                                                {
+                                                    positionHasSimilarOnes = true;
+                                                }
+                                            }
+                                        }
                                         <span class="sort-percents">@positionCount</span>
                                     }
                                 }
                             </td>
                         }
-                        @if (Model.SimilarSearchIds.Contains(item.JobTitleId))
+                        @if (Model.CopyingAPosition)
                         {
-                            <td class="text-center">
-                                <a asp-page="./Details" asp-route-id="@item.JobTitleId">Details</a> |
-                                <a asp-page="./Edit" asp-route-id="@item.JobTitleId">Edit</a>
-                            </td>
+                            if (positionHasSimilarOnes)
+                            {
+                                <td class="text-center">
+                                    <a href="" data-toggle="modal" data-target="#modalOverwriteSimilar" 
+                                        class="overwrite-similar-link" value="@item.JobTitleId">Overwrite</a>
+                                </td>
+                            }
+                            else
+                            {
+                                <td class="text-center">
+                                    <a href="/Similar/Create?id=@item.JobTitleId&copyid=@Model.PositionBeingCopied.JobTitleId">Apply</a>
+                                </td>
+                            }
                         }
                         else
                         {
-                            <td class="text-center">
-                                <a asp-page="./Create" asp-route-id="@item.JobTitleId">Create</a>
-                            </td>
+                            @if (Model.SimilarSearchIds.Contains(item.JobTitleId))
+                            {
+                                <td class="text-center">
+                                    <a asp-page="./Details" asp-route-id="@item.JobTitleId">Details</a> |
+                                    <a asp-page="./Edit" asp-route-id="@item.JobTitleId">Edit</a>
+                                </td>
+                            }
+                            else
+                            {
+                                <td class="text-center">
+                                    <a asp-page="./Create" asp-route-id="@item.JobTitleId">Create</a>
+                                </td>
+                            }
                         }
                     </tr>
                 }
             </tbody>
         </table>
     </div>
+
+    @if (Model.CopyingAPosition)
+    {
+         <div class="modal fade bd-modal-xl" id="modalOverwriteSimilar" tabindex="-1" role="dialog" 
+            aria-labelledby="modalOverwriteSimilarTitle" aria-hidden="true">
+            <div class="modal-dialog modal-dialog-centered modal-xl" role="document">
+                <div class="modal-content">
+                    <div class="modal-header">
+                        <h5 class="modal-title" id="modalOverwriteSimilarTitle">
+                            OVERWRITE SIMILAR POSITIONS WARNING 
+                        </h5>
+                        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                            <span aria-hidden="true">&times;</span>
+                        </button>
+                    </div>
+                    <div class="modal-body">
+                        <div class="card-body text-center">
+                            <h3 class="text-center">
+                                The position you have selected already has similar positions. 
+                                By proceeding, you may overwrite this data and permanently lose it (only if you 
+                                decide to save changes on the next screen, however). Do you wish to proceed?
+                            </h3>
+                        </div>
+                        <div class="modal-footer">
+                            <button type="button" class="btn btn-secondary" data-dismiss="modal">Cancel</button>
+                            <a class="btn btn-primary" id="btn-modal-overwrite-similar">Yes</a>
+                            @* The href of this links gets set when the user clicks on an "Overwrite" link using javascript *@
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <p class="dontShow" id="position-copied-id">@Model.PositionBeingCopied.JobTitleId</p>
+    }
 }
 else
 {
@@ -161,4 +269,3 @@ else
         <h4 class="no-results">There are currently no positions</h4>
     }
 }
-

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -91,6 +91,8 @@ body {
     --btnSecondaryColour: #5a6268;
     --btnDangerColour: #dc3545;
     --lightBlue: rgb(108, 213, 254);
+    --visitedLinkColour: #5a6268;
+    --btnDarkColour: rgb(52, 58, 64);
     /* --scrollbarTrack: #2e3338; */
     --tableHeaderBgColour: #f2f2f2;
     --scrollbarTrack: #5a6268;
@@ -158,6 +160,16 @@ h4.no-results {
     margin-top: 50px;
 }
 
+.no-matching-positions-at-percent span {
+    position: sticky !important;
+    width: 80%;
+    display: block;
+    margin: auto !important;
+    text-align: center;
+    font-weight: bold;
+    font-size: 1.1em;
+}
+
 .vertical-bar {
     font-size: 1.4em;
     position: relative;
@@ -177,6 +189,10 @@ h4.no-results {
     display: block !important;
 }
 
+.display-inline {
+    display: inline !important;
+}
+
 .expanded-item-navigation {
     margin-top: 25px;
 }
@@ -186,9 +202,9 @@ h4.no-results {
     user-select: none;
 }
 
-.expand-all-children:hover, .expand-elements-in-next-rows:hover {
-    opacity: 0.8;
-}
+    .expand-all-children:hover, .expand-elements-in-next-rows:hover {
+        opacity: 0.8;
+    }
 
 .remove-btn {
     color: red;
@@ -219,8 +235,16 @@ h4.no-results {
     margin-top: 25px !important;
 }
 
+.large-margin-top {
+    margin-top: 40px !important;
+}
+
 .small-margin-bottom {
     margin-bottom: 25px;
+}
+
+.xs-margin-bottom {
+    margin-bottom: 15px;
 }
 
 .small-padding-bottom {
@@ -394,6 +418,10 @@ textarea.form-control {
     padding: 0px !important;
 }
 
+.no-padding-right {
+    padding-right: 0px !important;
+}
+
 .nav-item {
     padding-top: 8px;
     padding-bottom: 6px;
@@ -416,21 +444,21 @@ textarea.form-control {
     color: var(--btnPrimary) !important;
 }
 
-    .nav-item:not(.selected) .nav-link::after, .smooth-underline::after {
-        content: '';
-        display: block;
-        position: relative;
-        top: 2px;
-        width: auto;
-        height: 2px;
-        opacity: 0;
-    }
+.nav-item:not(.selected) .nav-link::after, .smooth-underline::after {
+    content: '';
+    display: block;
+    position: relative;
+    top: 2px;
+    width: auto;
+    height: 2px;
+    opacity: 0;
+}
 
-    .nav-item.selected {
-        padding-bottom: 0px;
-        border-bottom: 6px solid var(--btnPrimary) !important;
-        transition: border-bottom 0.3s !important;
-    }
+.nav-item.selected {
+    padding-bottom: 0px;
+    border-bottom: 6px solid var(--btnPrimary) !important;
+    transition: border-bottom 0.3s !important;
+}
 
 .smooth-underline::after {
     background-color: var(--btnPrimary) !important;
@@ -501,36 +529,40 @@ a:hover .external-link {
 
 .home-page-card {
     width: 20rem;
+    border-radius: 12px;
+    padding: 5px;
+    box-shadow: 0px 1px 1px hsla(206, 48%, 24%, 0.1), 0px 2px 4px hsla(206, 48%, 24%, 0.1);
 }
 
-.sort-column, .sort-column-percents {
+.sort-column, .sort-column-percents, .flip-column {
     cursor: pointer;
     user-select: none;
 }
 
-.sort-column:hover, .sort-column-percents:hover {
-    opacity: 0.7;
-}
+    .sort-column:hover, .sort-column-percents:hover, .flip-column:hover {
+        opacity: 0.7;
+    }
 
-.sort-column.sorted::after, .sort-column-percents.sorted::after, 
-.sort-column.reverse-sorted::after, .sort-column-percents.reverse-sorted::after {
-    position: relative;
-    left: 4px;
-    font-family: 'Segoe UI Symbol';
-    font-size: 0.65em;
-}
+    .sort-column.sorted::after, .sort-column-percents.sorted::after,
+    .sort-column.reverse-sorted::after, .sort-column-percents.reverse-sorted::after,
+    .flip-column.sorted::after, .flip-column.reverse-sorted::after {
+        position: relative;
+        left: 4px;
+        font-family: 'Segoe UI Symbol';
+        font-size: 0.65em;
+    }
 
-.sort-column.sorted::after, .sort-column-percents.sorted::after {
-    content: "\1f53a";
-    bottom: 5px;
-}
+    .sort-column.sorted::after, .sort-column-percents.sorted::after, .flip-column.sorted::after {
+        content: "\1f53a";
+        bottom: 5px;
+    }
 
-.sort-column.reverse-sorted::after, .sort-column-percents.reverse-sorted::after {
-    content: "\1f53b";
-    top: 0px;
-}
+    .sort-column.reverse-sorted::after, .sort-column-percents.reverse-sorted::after, .flip-column.reverse-sorted::after {
+        content: "\1f53b";
+        top: 0px;
+    }
 
-.glyphicon-save-file:before {
+.glyphicon-save-file::before {
     content: "\e202";
 }
 
@@ -538,14 +570,17 @@ a:hover .external-link {
     font-size: 35px;
     background: #fff;
     border-radius: 999px;
+}
+
+.relatively-down {
     position: relative;
     top: 15px;
 }
 
-.glyphicon:hover {
-    cursor: pointer;
-    opacity: 0.7;
-}
+    .glyphicon:hover {
+        cursor: pointer;
+        opacity: 0.7;
+    }
 
 .remove-all-btn {
     margin-right: 5px;
@@ -560,12 +595,105 @@ a:hover .external-link {
     margin-bottom: 0px !important;
 }
 
+.underline {
+    text-decoration: underline;
+}
+
+a.visited {
+    color: purple;
+}
+
+.no-margin-right {
+    margin-right: 0px !important;
+}
+
+.vertical-margin-auto {
+    margin-top: auto;
+    margin-bottom: auto;
+}
+
+.table-display {
+    display: table;
+}
+
+.vertical-center {
+    display: table-cell !important;
+    vertical-align: middle;
+}
+
+.raise-elements-slightly > * {
+    position: relative;
+    top: -10px !important;
+}
+
+.hide-when-not-in-print, *.hide-when-not-in-print {
+    display: none !important;
+}
+
+.table-cell {
+    display: table-cell;
+}
+
+.no-padding-top {
+    padding-top: 0px !important;
+}
+
+.field-validation-error {
+    padding-top: 10px;
+    display: block;
+}
+
+textarea.big-textarea {
+    min-height: 250px;
+}
+
 @media print {
 
     .glyphicon {
         display: none !important;
     }
-    
+
+    a[href]::after {
+        content: '' !important;
+    }
+
+    .hide-in-print {
+        display: none !important;
+    }
+
+    .col-3 {
+        width: 25% !important;
+    }
+
+    .col-2 {
+        width: 16.66% !important;
+    }
+
+    .col-1 {
+        width: 8.33% !important;
+    }
+
+    #table-container {
+        max-height: none !important;
+        min-height: none !important;
+    }
+
+    .external-link {
+        display: none !important;
+    }
+
+    a {
+        text-decoration: none !important;
+    }
+
+    .hide-when-not-in-print {
+        display: initial;
+    }
+
+    .table-cell {
+        display: table-cell !important;
+    }
+
 }
 
 /* header {


### PR DESCRIPTION
Full list of changes:

-Added feature that lets users copy similar positions to another. By going to a position that already has similar positions (either on the edit or details page), a button will appear with the text "Copy Similar Positions". Clicking on it brings users to a special version of the similar positions index page, where they can now choose over which position the similar positions should be copied. Positions that currently have no similar positions will have the text "Apply" next to them, and those that already have similar positions will instead have the word "Overwrite". Selecting a position with "Apply" brings up no warning, however, if the user selects an "Overwrite" option, they will see a modal window with a confirmation that they may overwrite data and lose it, if they choose to proceed. On that index page, the user can also cancel the copy, which will bring them back to the similar position details. Regardless of if they chose to apply or overwrite, the user will be brought to the same page, which is similar positions create. The difference is that they will see the similar positions that they have copied already filled out for all four percentage matches. At this point, the user is free to do any modifications to those similar positions as they see fit, but their changes will only apply once they click on the Save Changes button (at this point, any previous similar positions data will be lost for that position)

-Added a "Remove all" button on edit/create similar positions to remove all positions added to a percentage match

Small fixes:

-Changed the naming of the button that lets users see the list of the number of similar positions added per position. It now says "View / Print List"

-On the executive summary page (the list of the number of matching similar positions added per position), the application footer now displays

-CSS and javaScript updates, most of which apply to future PRs