### PR TITLE
Added feature to locate added similar positions

### DIFF
--- a/Admin/Pages/Shared/_Layout.cshtml
+++ b/Admin/Pages/Shared/_Layout.cshtml
@@ -15,7 +15,7 @@
 </head>
 <body>
     <header>
-        <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3 no-padding">
+        <nav class="navbar navbar-expand-sm rememberIfVisited navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3 no-padding">
             <div class="container">
                 <a class="navbar-brand smooth-underline" asp-area="" asp-page="/Index">CCG CCT Admin</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
@@ -25,22 +25,22 @@
                 <div class="navbar-collapse collapse d-sm-inline-flex flex-sm-row-reverse">
                     <ul class="navbar-nav flex-grow-1">
                         <li class="nav-item" id="navHome">
-                            <a class="nav-link" href="/Index">Home</a>
+                            <a class="nav-link rememberIfVisited" href="/Index">Home</a>
                         </li>
                         <li class="nav-item" id="navCertificates">
-                            <a class="nav-link" href="/Certificates">Certificates</a>
+                            <a class="nav-link rememberIfVisited" href="/Certificates">Certificates</a>
                         </li>
                         <li class="nav-item" id="navCertDesc">
-                            <a class="nav-link" href="/Certificates/Descriptions">Certificate Descriptions</a>
+                            <a class="nav-link rememberIfVisited" href="/Certificates/Descriptions">Certificate Descriptions</a>
                         </li>
                         <li class="nav-item" id="navPositions">
-                            <a class="nav-link" href="/Positions">Positions</a>
+                            <a class="nav-link rememberIfVisited" href="/Positions">Positions</a>
                         </li>
                         <li class="nav-item" id="navCompetencies">
-                            <a class="nav-link" href="/Competencies/List?typeid=1">Competencies</a>
+                            <a class="nav-link rememberIfVisited" href="/Competencies/List?typeid=1">Competencies</a>
                         </li>
                         <li class="nav-item" id="navSimilar">
-                            <a class="nav-link" href="/Similar">Similar Positions</a>
+                            <a class="nav-link rememberIfVisited" href="/Similar">Similar Positions</a>
                         </li>
                     </ul>
                 </div>

--- a/Admin/Pages/Similar/Create.cshtml.cs
+++ b/Admin/Pages/Similar/Create.cshtml.cs
@@ -300,14 +300,19 @@ namespace Admin.Pages.Similar
 
             if (creatingSimilarPositions)
             {
-                _jobPositionService.PostSimilarPositions(new SearchSimilarJob()
+
+                try
                 {
-                    Position = Id,
-                    HundredPercent = querystring100,
-                    NinetyPercent = querystring90,
-                    EightyPercent = querystring80,
-                    SeventyPercent = querystring70,
-                });
+                    await _jobPositionService.PostSimilarPositions(new SearchSimilarJob()
+                    {
+                        Position = Id,
+                        HundredPercent = querystring100,
+                        NinetyPercent = querystring90,
+                        EightyPercent = querystring80,
+                        SeventyPercent = querystring70,
+                    });
+                }
+                catch { }
             }
             else
             {
@@ -315,10 +320,14 @@ namespace Admin.Pages.Similar
                 JobPosition.NinetyPercent = querystring90;
                 JobPosition.EightyPercent = querystring80;
                 JobPosition.SeventyPercent = querystring70;
-                _jobPositionService.UpdateSimilarPositions(JobPosition);
+
+                try
+                {
+                    await _jobPositionService.UpdateSimilarPositions(JobPosition);
+                }
+                catch { }
             }
 
-            Thread.Sleep(5000);
             return RedirectToPage("Details", new { Id });
         }
         public async Task OnPostGroupOneHundredPercent()

--- a/Admin/Pages/Similar/Edit.cshtml.cs
+++ b/Admin/Pages/Similar/Edit.cshtml.cs
@@ -320,8 +320,13 @@ namespace Admin.Pages.Similar
             JobPosition.NinetyPercent = querystring90;
             JobPosition.EightyPercent = querystring80;
             JobPosition.SeventyPercent = querystring70;
-            _jobPositionService.UpdateSimilarPositions(JobPosition);
-            Thread.Sleep(5000);
+
+            try
+            {
+                await _jobPositionService.UpdateSimilarPositions(JobPosition);
+            }
+            catch { }
+
             return RedirectToPage("Details", new { Id });
         }
         public async Task OnPostGroupOneHundredPercent()

--- a/Admin/Pages/Similar/Index.cshtml
+++ b/Admin/Pages/Similar/Index.cshtml
@@ -43,6 +43,12 @@
 
         itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
         var itemsList = itemsThatMatchFilter.ToList();
+
+        if (Model.CopyingAPosition)
+        {
+            // this is so that you can't copy similar positions onto the same position
+            itemsList = itemsList.Where(x => x.JobTitleId != Model.PositionBeingCopied.JobTitleId).ToList();
+        }
     }
 
     <form>

--- a/Admin/Pages/Similar/Locate.cshtml
+++ b/Admin/Pages/Similar/Locate.cshtml
@@ -54,7 +54,7 @@
                         </span>
                     }
 
-                    <a class="btn btn-secondary pull-right bottom-two-px bold index-right-button" asp-page="Index">Back to Index</a>
+                    <a class="btn btn-secondary pull-right bottom-two-px bold index-right-button" asp-page="Index">Back to List</a>
                 </h6>
             </div>
         </form>
@@ -88,7 +88,7 @@
                         <h6 class="glyphicon glyphicon-save-file display-inline position-relative" style="top: 4px !important; right: 5px;" onclick="print()"></h6>
                     }
                     <h6 class="display-inline"><a class="btn btn-primary bold bottom-two-px" href="/Similar/Locate">Locate Another Position</a></h6>
-                    <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" asp-page="Index">Back to Index</a>
+                    <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" asp-page="Index">Back to List</a>
                 </div>
             </div>
         </div>

--- a/Admin/Pages/Similar/Locate.cshtml
+++ b/Admin/Pages/Similar/Locate.cshtml
@@ -1,0 +1,388 @@
+﻿@page
+@model Admin.Pages.Similar.LocateModel
+@using Business.Dtos.JobPositions
+@{
+    ViewData["Title"] = "Locate Similar Positions";
+
+    bool addedInOnePlace = false;
+
+    if (Model.LocatingAPosition)
+    {
+        addedInOnePlace = (Model.PositionsThatHaveItAtHundredMatch.Any() ||
+                            Model.PositionsThatHaveItAtNinetyMatch.Any() ||
+                            Model.PositionsThatHaveItAtEightyMatch.Any() ||
+                            Model.PositionsThatHaveItAtSeventyMatch.Any());
+    }
+}
+
+@functions {
+
+    public List<JobPositionDto> PutJobPositionBeingSearchedFirstInList(List<JobPositionDto> positions)
+    {
+        if (!positions.Any())
+        {
+            return positions;
+        }
+
+        if (positions.Select(x => x.JobTitleId).Contains(Model.PositionBengLocated.JobTitleId))
+        {
+            var samePosition = positions.Where(x => x.JobTitleId == Model.PositionBengLocated.JobTitleId).FirstOrDefault();
+            positions.Remove(samePosition);
+            positions.Insert(0, samePosition);
+        }
+        return positions;
+    }
+
+}
+
+<div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
+    @if (!Model.LocatingAPosition)
+    {
+        <h1>Locate Similar Positions</h1>
+
+        <form>
+            <div class="form-actions no-color">
+                <h6>
+                    <label for="Filter">Find positions:</label>
+                    <input type="text" asp-for="@Model.Filter" />
+
+                    <input type="submit" value="Search" class="btn btn-primary" /> 
+                    @if (!String.IsNullOrWhiteSpace(Model.Filter))
+                    {
+                        <span><span class="vertical-bar">|</span> 
+                            <a href="/Similar/Locate">Back to Full List</a>
+                        </span>
+                    }
+
+                    <a class="btn btn-secondary pull-right bottom-two-px bold index-right-button" asp-page="Index">Back to Index</a>
+                </h6>
+            </div>
+        </form>
+    }
+    else
+    {
+        <h4 class="small-margin-bottom">Located Position: 
+            <a target="_blank" href="/Positions/Details?positionid=@Model.PositionBengLocated.JobTitleId">
+                <span id="jobTitleEng">@Model.PositionBengLocated.JobGroupLevelCode @Model.PositionBengLocated.JobTitleEng</span>
+                <span id="jobTitleFre" class="dontShow">@Model.PositionBengLocated.JobGroupLevelCode @Model.PositionBengLocated.JobTitleFre</span>
+                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+            </a>
+        </h4>
+
+        <div class="space-btns no-margin-right small-margin-bottom large-margin-top no-padding-right container hide-in-print">
+            <div class="row no-margin-right">
+                <div class="col text-left no-padding table-display">
+                    <span class="display-block vertical-margin-auto vertical-center">
+                        <label class="no-margin-bottom">Display job titles in: &nbsp;&nbsp;</label> 
+                        <input type="radio" value="eng" name="changeLang" id="changeLangEnglish" checked />
+                        <label for="changeLangEnglish" class="no-margin-bottom">English</label>
+
+                        <input type="radio" value="fre" name="changeLang" id="changeLangFrench" />
+                        <label for="changeLangFrench" class="no-margin-bottom">French</label>
+                    </span>
+                </div>
+
+                <div class="col text-right no-margin-right no-padding @(addedInOnePlace ? "raise-elements-slightly" : "")" style="max-height: 38px">
+                    @if (addedInOnePlace)
+                    {
+                        <h6 class="glyphicon glyphicon-save-file display-inline position-relative" style="top: 4px !important; right: 5px;" onclick="print()"></h6>
+                    }
+                    <h6 class="display-inline"><a class="btn btn-primary bold bottom-two-px" href="/Similar/Locate">Locate Another Position</a></h6>
+                    <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" asp-page="Index">Back to Index</a>
+                </div>
+            </div>
+        </div>
+    }
+
+    @{
+        string? filterValue = Model.Filter;
+        if (filterValue != null)
+        {
+            filterValue = filterValue.Trim();
+        }
+
+        var itemsThatMatchFilter = Model.JobPositions.Where(e => (Model.Filter == null
+            || e.JobTitleEng.ToLower().Contains(Model.Filter.ToLower())
+            || e.JobTitleFre.ToLower().Contains(Model.Filter.ToLower())
+            || e.LevelCode.ToLower().Contains(Model.Filter.ToLower()))
+            && (e.Active == 1));
+
+        itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+        var itemsList = itemsThatMatchFilter.ToList();
+    }
+</div>
+
+@if (!Model.LocatingAPosition)
+{
+    @if (itemsThatMatchFilter.Any())
+    {
+        <div id="table-container">
+            <table class="table">
+                <thead>
+                    <tr class="table-header-row text-center">
+                            <th class="col-1"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                            <th class="col-4"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                            <th class="col-5"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
+                            <th class="col-2">
+                                <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                                class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
+                                aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                                alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                                title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                            </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in itemsList)
+                    {
+
+                        <tr>
+                            <td class="text-center sort-percents">
+                                @Html.DisplayFor(modelItem => item.LevelCode)
+                            </td>
+                            <td class="sort-percents">
+                                @Html.DisplayFor(modelItem => item.JobTitleEng)
+                            </td>
+                            <td class="sort-percents">
+                                @Html.DisplayFor(modelItem => item.JobTitleFre)
+                            </td>
+                             <td class="text-center">
+                                <a href="/Similar/Locate?id=@item.JobTitleId">Locate</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        if (!string.IsNullOrWhiteSpace(Model.Filter))
+        {
+            <h4 class="no-results">No positions match the filter "@Model.Filter"</h4>
+        }
+        else
+        {
+            <h4 class="no-results">There are currently no positions</h4>
+        }
+    }
+}
+else 
+{
+
+    if (addedInOnePlace) 
+    {
+        var hundredPositions = Model.PositionsThatHaveItAtHundredMatch.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+        var ninetyPositions = Model.PositionsThatHaveItAtNinetyMatch.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+        var eightyPositions = Model.PositionsThatHaveItAtEightyMatch.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+        var seventyPositions = Model.PositionsThatHaveItAtSeventyMatch.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+
+        hundredPositions = PutJobPositionBeingSearchedFirstInList(hundredPositions);
+        ninetyPositions = PutJobPositionBeingSearchedFirstInList(ninetyPositions);
+        eightyPositions = PutJobPositionBeingSearchedFirstInList(eightyPositions);
+        seventyPositions = PutJobPositionBeingSearchedFirstInList(seventyPositions);
+
+        var hunredIsEmpty = !hundredPositions.Any();
+        var ninetyIsEmpty = !ninetyPositions.Any();
+        var eightyIsEmpty = !eightyPositions.Any();
+        var seventyIsEmpty = !seventyPositions.Any();
+
+        int[] arrayLengths = { hundredPositions.Count(), ninetyPositions.Count(),
+            eightyPositions.Count(), seventyPositions.Count(), };
+        int numRows = arrayLengths.Max();
+
+        <div id="table-container">
+            <table class="table">
+                <thead>
+                    <tr class="table-header-row text-center">
+                            <th class="col-3"><b class="@(!hunredIsEmpty ? "sorted flip-column" : "")" title="@(!hunredIsEmpty ? "Click to flip column" : "")" data-toggle="@(hundredPositions.Any() ? "tooltip" : "")">100% (@hundredPositions.Count())</b></th>
+                            <th class="col-3"><b class="@(!ninetyIsEmpty ? "sorted flip-column" : "")" title="@(!ninetyIsEmpty ? "Click to flip column" : "")" data-toggle="@(ninetyPositions.Any() ? "tooltip" : "")">90% (@ninetyPositions.Count())</b></th>
+                            <th class="col-3"><b class="@(!eightyIsEmpty ? "sorted flip-column" : "")" title="@(!eightyIsEmpty ? "Click to flip column" : "")" data-toggle="@(eightyPositions.Any() ? "tooltip" : "")">80% (@eightyPositions.Count())</b></th>
+                            <th class="col-2 hide-in-print"><b class="@(!seventyIsEmpty ? "sorted flip-column" : "")" title="@(!seventyIsEmpty ? "Click to flip column" : "")" data-toggle="@(seventyPositions.Any() ? "tooltip" : "")">70% (@seventyPositions.Count())</b></th>
+                            <th class="col-1 hide-in-print">
+                                <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                                class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
+                                aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                                alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                                title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                            </th>
+                            <th class="col-3 hide-when-not-in-print table-cell"><b class="@(!seventyIsEmpty ? "sorted flip-column" : "")">70% (@seventyPositions.Count())</b></th>
+                    </tr>
+                </thead>
+                <tbody>
+
+                    @{
+                        string urlEnd = "&groupId=" + Model.PositionBengLocated.JobGroupId + "&level=" + Model.PositionBengLocated.LevelCode.ToUpper();
+                    }
+
+                    @for (int i = 0; i < numRows; i++)
+                    {
+                        JobPositionDto hundredPos = null, ninetyPos = null, eightyPos = null, seventyPos = null;
+                        try
+                        {
+                            hundredPos = hundredPositions.ElementAt(i);
+                        }
+                        catch { }
+                        try
+                        {
+                            ninetyPos = ninetyPositions.ElementAt(i);
+                        }
+                        catch { }
+                        try
+                        {
+                            eightyPos = eightyPositions.ElementAt(i);
+                        }
+                        catch { }
+                        try
+                        {
+                            seventyPos = seventyPositions.ElementAt(i);
+                        }
+                        catch { }
+
+                        <tr>
+                            @if (hunredIsEmpty && i == 0)
+                            {
+                                <td rowspan="@numRows" class="no-matching-positions-at-percent">
+                                    <span>
+                                        This position has not been added to any other positions at 100% match
+                                    </span>
+                                </td>
+                            }
+                            else
+                            {
+                                if (!hunredIsEmpty)
+                                {
+                                    <td>
+                                        @if (hundredPos != null)
+                                        {
+                                            <a href="/Similar/Edit?id=@hundredPos.JobTitleId&percent=100@(urlEnd)" target="_blank" lang="en"
+                                                class="@(hundredPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                @hundredPos.JobGroupLevelCode @hundredPos.JobTitleEng
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                            <a href="/Similar/Edit?id=@hundredPos.JobTitleId&percent=100@(urlEnd)" target="_blank" lang="fr"
+                                                class="@(hundredPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                @hundredPos.JobGroupLevelCode @hundredPos.JobTitleFre
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                        }
+                                        else
+                                        {
+                                            <span></span>
+                                        }
+                                    </td>
+                                }
+                            }
+
+                            @if (ninetyIsEmpty && i == 0)
+                            {
+                                <td rowspan="@numRows" class="no-matching-positions-at-percent">
+                                    <span>
+                                        This position has not been added to any other positions at 90% match
+                                    </span>
+                                </td>
+                            }
+                            else
+                            {
+                                if (!ninetyIsEmpty)
+                                {
+                                    <td>
+                                        @if (ninetyPos != null)
+                                        {
+                                            <a href="/Similar/Edit?id=@ninetyPos.JobTitleId&percent=90@(urlEnd)" target="_blank" lang="en"
+                                                class="@(ninetyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                @ninetyPos.JobGroupLevelCode @ninetyPos.JobTitleEng
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                            <a href="/Similar/Edit?id=@ninetyPos.JobTitleId&percent=90@(urlEnd)" target="_blank" lang="fr"
+                                                class="@(ninetyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                @ninetyPos.JobGroupLevelCode @ninetyPos.JobTitleFre
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                        }
+                                        else
+                                        {
+                                            <span></span>
+                                        }
+                                    </td>
+                                }
+                            }
+
+                            @if (eightyIsEmpty && i == 0)
+                            {
+                                <td rowspan="@numRows" class="no-matching-positions-at-percent">
+                                    <span>
+                                        This position has not been added to any other positions at 80% match
+                                    </span>
+                                </td>
+                            }
+                            else
+                            {
+                                if (!eightyIsEmpty)
+                                {
+                                    <td>
+                                        @if (eightyPos != null)
+                                        {
+                                            <a href="/Similar/Edit?id=@eightyPos.JobTitleId&percent=80@(urlEnd)" target="_blank" lang="en"
+                                                class="@(eightyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                @eightyPos.JobGroupLevelCode @eightyPos.JobTitleEng
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                            <a href="/Similar/Edit?id=@eightyPos.JobTitleId&percent=80@(urlEnd)" target="_blank" lang="fr"
+                                                class="@(eightyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                @eightyPos.JobGroupLevelCode @eightyPos.JobTitleFre
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                        }
+                                        else
+                                        {
+                                            <span></span>
+                                        }
+                                    </td>
+                                }
+                            }
+
+                            @if (seventyIsEmpty && i == 0)
+                            {
+                                <td rowspan="@numRows" colspan="2" class="no-matching-positions-at-percent">
+                                    <span>
+                                        This position has not been added to any other positions at 70% match
+                                    </span>
+                                </td>
+                            }
+                            else
+                            {
+                                if (!seventyIsEmpty)
+                                {
+                                    <td colspan="2">
+                                        @if (seventyPos != null)
+                                        {
+                                            <a href="/Similar/Edit?id=@seventyPos.JobTitleId&percent=70@(urlEnd)" target="_blank" lang="en"
+                                                class="@(seventyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                @seventyPos.JobGroupLevelCode @seventyPos.JobTitleEng
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                            <a href="/Similar/Edit?id=@seventyPos.JobTitleId&percent=70@(urlEnd)" target="_blank" lang="fr"
+                                                class="@(seventyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                @seventyPos.JobGroupLevelCode @seventyPos.JobTitleFre
+                                                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                            </a>
+                                        }
+                                        else
+                                        {
+                                            <span></span>
+                                        }
+                                    </td>
+                                }
+                            }
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else 
+    {
+        <h4 class="no-results">This position has not been added to any similar positions</h4>
+    }
+}

--- a/Admin/Pages/Similar/Locate.cshtml.cs
+++ b/Admin/Pages/Similar/Locate.cshtml.cs
@@ -1,0 +1,179 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Admin.Data;
+using Business.Dtos.JobPositions;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using DataModel;
+using Microsoft.AspNetCore.Http;
+
+namespace Admin.Pages.Similar
+{
+    public class LocateModel : PageModel
+    {
+        private readonly DataModel.CctDbContext _context;
+
+        private readonly JobPositionService _jobPositionService;
+
+        public LocateModel(DataModel.CctDbContext context, JobPositionService jobPositionService)
+        {
+            _context = context;
+            _jobPositionService = jobPositionService;
+        }
+        [BindProperty(SupportsGet = true)]
+        public string Filter { get; set; }
+        public IList<JobPositionDto> JobPositions { get; set; }
+        public int[] SimilarSearchIds { get; set; }
+
+        [BindProperty]
+        public SearchSimilarJob JobPosition { get; set; }
+
+        public bool DisplayTopOfPage { get; set; }
+
+        public bool LocatingAPosition { get; set; } = false;
+
+        public JobPositionDto PositionBengLocated { get; set; }
+
+        public List<JobPositionDto> PositionsThatHaveItAtHundredMatch { get; set; }
+
+        public List<JobPositionDto> PositionsThatHaveItAtNinetyMatch { get; set; }
+        
+        public List<JobPositionDto> PositionsThatHaveItAtEightyMatch { get; set; }
+
+        public List<JobPositionDto> PositionsThatHaveItAtSeventyMatch { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            DisplayTopOfPage = true;
+            var sessionStr = HttpContext.Session.GetString("displayTopOfPage");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (sessionStr.ToLower() == "false")
+                {
+                    DisplayTopOfPage = false;
+                }
+            }
+
+            JobPositions = (await _jobPositionService.GetAllJobPositions()).Where(x => x.Active == 1).ToList();
+            SimilarSearchIds = await _jobPositionService.GetAllSimilarSearchIds();
+
+            if (id != null)
+            {
+                try
+                {
+                    PositionBengLocated = await _jobPositionService.GetJobPositionById(id.Value);
+                }
+                catch
+                {
+                    PositionBengLocated = null;
+                }
+
+                if (PositionBengLocated != null)
+                {
+                    if (PositionBengLocated.Active == 1)
+                    {
+                        LocatingAPosition = true;
+                    }
+                }
+            }
+
+            if (LocatingAPosition)
+            {
+                var activeJobIds = JobPositions.Select(x => x.JobTitleId).ToList();
+                SimilarSearchIds = SimilarSearchIds.Where(x => activeJobIds.Contains(x)).ToArray();
+                int idToLookFor = id.Value;
+                var positionsToLookThrough = await _context.SearchSimilarJobs.Where(x => SimilarSearchIds.Contains(x.Position)).ToListAsync();
+
+                PositionsThatHaveItAtHundredMatch = new List<JobPositionDto>();
+                PositionsThatHaveItAtNinetyMatch = new List<JobPositionDto>();
+                PositionsThatHaveItAtEightyMatch = new List<JobPositionDto>();
+                PositionsThatHaveItAtSeventyMatch = new List<JobPositionDto>();
+
+                foreach (var pos in positionsToLookThrough)
+                {
+                    var hundredIds = pos.HundredPercent.Split("&PositionId=").Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+                    var ninetyIds = pos.NinetyPercent.Split("&PositionId=").Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+                    var eightyIds = pos.EightyPercent.Split("&PositionId=").Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+                    var seventyIds = pos.SeventyPercent.Split("&PositionId=").Where(x => !string.IsNullOrWhiteSpace(x)).ToList();
+
+                    bool addedThisJob = false;
+
+                    foreach (var jobId in hundredIds)
+                    {
+                        try
+                        {
+                            int intId = int.Parse(jobId);
+                            if (intId == idToLookFor)
+                            {
+                                PositionsThatHaveItAtHundredMatch.Add(JobPositions.Where(x => x.JobTitleId == pos.Position).FirstOrDefault());
+                                addedThisJob = true;
+                                break;
+                            }
+                        }
+                        catch { }
+                    }
+
+                    if (!addedThisJob)
+                    {
+                        foreach (var jobId in ninetyIds)
+                        {
+                            try
+                            {
+                                int intId = int.Parse(jobId);
+                                if (intId == idToLookFor)
+                                {
+                                    PositionsThatHaveItAtNinetyMatch.Add(JobPositions.Where(x => x.JobTitleId == pos.Position).FirstOrDefault());
+                                    addedThisJob = true;
+                                    break;
+                                }
+                            }
+                            catch { }
+                        }
+                    }
+
+                    if (!addedThisJob)
+                    {
+                        foreach (var jobId in eightyIds)
+                        {
+                            try
+                            {
+                                int intId = int.Parse(jobId);
+                                if (intId == idToLookFor)
+                                {
+                                    PositionsThatHaveItAtEightyMatch.Add(JobPositions.Where(x => x.JobTitleId == pos.Position).FirstOrDefault());
+                                    addedThisJob = true;
+                                    break;
+                                }
+                            }
+                            catch { }
+                        }
+                    }
+
+                    if (!addedThisJob)
+                    {
+                        foreach (var jobId in seventyIds)
+                        {
+                            try
+                            {
+                                int intId = int.Parse(jobId);
+                                if (intId == idToLookFor)
+                                {
+                                    PositionsThatHaveItAtSeventyMatch.Add(JobPositions.Where(x => x.JobTitleId == pos.Position).FirstOrDefault());
+                                    addedThisJob = true;
+                                    break;
+                                }
+                            }
+                            catch { }
+                        }
+                    }
+
+                }
+            }
+
+            return Page();
+        }
+
+    }
+}

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -440,19 +440,19 @@ textarea.form-control {
     cursor: default !important;
 }
 
-.nav-item:not(.selected) .nav-link:hover, .navbar-brand:hover, .nav-item:not(.selected) .nav-link:active, .navbar-brand:active {
+.nav-item:not(.selected) .nav-link:hover, .navbar-brand:hover, .nav-item:not(.selected), .nav-link.visited, .navbar-brand.visited {
     color: var(--btnPrimary) !important;
 }
 
-.nav-item:not(.selected) .nav-link::after, .smooth-underline::after {
-    content: '';
-    display: block;
-    position: relative;
-    top: 2px;
-    width: auto;
-    height: 2px;
-    opacity: 0;
-}
+    .nav-item:not(.selected) .nav-link::after, .smooth-underline::after {
+        content: '';
+        display: block;
+        position: relative;
+        top: 2px;
+        width: auto;
+        height: 2px;
+        opacity: 0;
+    }
 
 .nav-item.selected {
     padding-bottom: 0px;
@@ -577,10 +577,10 @@ a:hover .external-link {
     top: 15px;
 }
 
-    .glyphicon:hover {
-        cursor: pointer;
-        opacity: 0.7;
-    }
+.glyphicon:hover {
+    cursor: pointer;
+    opacity: 0.7;
+}
 
 .remove-all-btn {
     margin-right: 5px;
@@ -647,6 +647,32 @@ textarea.big-textarea {
     min-height: 250px;
 }
 
+.index-save-file-icon {
+    top: 10px;
+    right: 3px;
+}
+
+.index-right-button {
+    margin-right: 8px !important;
+}
+
+.index-right-button-no-scroll {
+    margin-right: 0px !important;
+}
+
+.inline-block {
+    display: inline-block !important;
+}
+
+.margin-left-link-spacing {
+    margin-left: 6px;
+}
+
+* {
+    word-wrap: break-word !important;
+    word-break: break-word !important;
+}
+
 @media print {
 
     .glyphicon {
@@ -661,21 +687,26 @@ textarea.big-textarea {
         display: none !important;
     }
 
-    .col-3 {
-        width: 25% !important;
+    .col-1 {
+        width: 8.33% !important;
     }
 
     .col-2 {
         width: 16.66% !important;
     }
 
-    .col-1 {
-        width: 8.33% !important;
+    .col-3 {
+        width: 25% !important;
+    }
+
+    .col-4 {
+        width: 33.33% !important;
     }
 
     #table-container {
         max-height: none !important;
         min-height: none !important;
+        height: fit-content !important;
     }
 
     .external-link {
@@ -693,7 +724,6 @@ textarea.big-textarea {
     .table-cell {
         display: table-cell !important;
     }
-
 }
 
 /* header {


### PR DESCRIPTION
**Full list of changes:**

- Added a feature that lets users find where positions have been added as similar positions. To use it, users must navigate to the similar positions index, and then click on the Locate Positions button. From there, the user will be greeted to a page similar to the similar positions index. From that page, they simply have to click on a "Locate" link next to any of the position titles. Once that is done, the user will be brought to the same page, however, this time it will be displaying the results of their search. The table is separated in 4 columns, one for each of the percent matches of similar positions. In each column where the position located was added as a similar position, the positions that added the one located will be listed (that wording is confusing, but it's fairly intuitive when using it). Those positions appear as hyperlinks which bring the user to the edit similar positions page of the position they clicked, with the corresponding percentage selected, as well as with the group and level selected of the position located (this is useful if the user wants to add a new position of that group and level). The job titles listed in the table appear by default in English only, but there are radio buttons that let users switch between French and English titles. Users can also print their search results. They can also flip any table column to reverse the sort order (every column is handled independently). From the search results screen, users can go back to the page that lets them choose the position they wish to search for, or go back to the similar positions index.

- Removed the delay that occurred when updating/creating similar positions when saving changes. This same change will come eventually to all other actions in the application

**Small fixes:**

- Navigation links, once clicked, will keep their blue colour until the next page loads (even if the user is no longer hovering over the link)

- Made it so the position having its similar positions copied doesn't appear in the list of positions over which to apply the similar positions. This is avoid copying them over themselves

- Repositioned certain buttons in certain cases where the main table isn't scrollable (part of this will come in a future PR, where the other index pages were modified)

- Added a global styling change that makes it so extremely long words can't overflow

*Note: there is currently a try/catch when saving changes for similar positions. This will be addressed in future PRs which will slightly change the API to avoid the need for this