### PR TITLE
Api and forms

### DIFF
--- a/Admin/Admin.csproj
+++ b/Admin/Admin.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>

--- a/Admin/Data/FormattingService.cs
+++ b/Admin/Data/FormattingService.cs
@@ -1,0 +1,61 @@
+﻿using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.EntityFrameworkCore;
+using System.Text.RegularExpressions;
+using Microsoft.AspNetCore.Http;
+
+namespace Admin.Data
+{
+    public class FormattingService
+    {
+
+        public string[] FormatCertificateDescriptionLink(string link)
+        {
+            if (string.IsNullOrWhiteSpace(link))
+            {
+                string[] res = { "", "" };
+                return res;
+            }
+            try
+            {
+                var trimmedLink = link.Trim();
+                bool correctMarkdown = false;
+                string pattern = "---\\S.+\\S---$";
+
+                if (Regex.Match(trimmedLink, pattern).Success)
+                {
+                    correctMarkdown = true;
+                }
+
+                string href = "", displayStr = "";
+
+                if (correctMarkdown)
+                {
+                    href = trimmedLink.Substring(trimmedLink.IndexOf("http"), (trimmedLink.IndexOf("---") - trimmedLink.IndexOf("http")));
+                    displayStr = trimmedLink.Substring(trimmedLink.IndexOf("---") + 3, (trimmedLink.LastIndexOf("---") - trimmedLink.IndexOf("---") - 3));
+                }
+                else
+                {
+                    href = trimmedLink;
+                    displayStr = trimmedLink;
+                }
+
+                string[] results = { href.Trim(), displayStr.Trim() };
+                return results;
+            }
+            catch 
+            {
+                string[] res = { link.Trim(), link.Trim() };
+                return res;
+            }
+        }
+
+    }
+}

--- a/Admin/Data/JobCertificateService.cs
+++ b/Admin/Data/JobCertificateService.cs
@@ -31,35 +31,35 @@ namespace Admin.Data
             using var httpClient = _clientFactory.CreateClient("api");
             return await httpClient.GetJsonAsync<JobCertificateDto>(url);
         }
-        public async Task<int> PostJobCertificate(string Parameters)
+        public async Task<int> PostJobCertificate(object Parameters)
         {
-            string url = $"/api/jobcertificates/addjobcertificate?{Parameters}";
+            string url = $"/api/jobcertificates/addjobcertificate";
             using var httpClient = _clientFactory.CreateClient("api");
-            return await httpClient.GetJsonAsync<int>(url);
+            return await httpClient.PostJsonAsync<int>(url, Parameters);
         }
         public async Task UpdateJobCertificate(object Parameters)
         {
             string url = $"/api/jobcertificates/updatejobcertificate?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task DeleteJobCertificate(object Parameters)
         {
             string url = $"/api/jobcertificates/deletejobcertificate?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
-        public async Task<int> PostJobCertificateDescription(string DescEng, string DescFre)
+        public async Task<int> PostJobCertificateDescription(object Parameters)
         {
-            string url = $"/api/jobcertificates/addjobcertificatedescription/{DescEng}/{DescFre}";
+            string url = $"/api/jobcertificates/addjobcertificatedescription";
             using var httpClient = _clientFactory.CreateClient("api");
-            return await httpClient.GetJsonAsync<int>(url);
+            return await httpClient.PostJsonAsync<int>(url, Parameters);
         }
         public async Task UpdateJobCertificateDescription(object Parameters)
         {
-            string url = $"/api/jobcertificates/updatejobcertificatedescription?";
+            string url = $"/api/jobcertificates/updatejobcertificatedescription";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task<JobCertificateDto[]> GetAllJobCertificateDescriptions()
         {
@@ -70,7 +70,7 @@ namespace Admin.Data
         {
             string url = $"/api/jobcertificates/deletejobcertificatedescription?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
     }
 }

--- a/Admin/Data/JobCompetencyService.cs
+++ b/Admin/Data/JobCompetencyService.cs
@@ -185,47 +185,47 @@ namespace Admin.Data
             using var httpClient = _clientFactory.CreateClient("api");
             return await httpClient.GetJsonAsync<JobCompetencyTypeDto>(url);
         }
-        public async Task<int> PostJobCompetency(string Parameters)
+        public async Task<int> PostJobCompetency(object Parameters)
         {
-            string url = $"/api/jobcompetencies/addjobcompetency?{Parameters}";
+            string url = $"/api/jobcompetencies/addjobcompetency";
             using var httpClient = _clientFactory.CreateClient("api");
-            return await httpClient.GetJsonAsync<int>(url);
+            return await httpClient.PostJsonAsync<int>(url, Parameters);
         }
-        public async Task<int> PostJobPositionGetId(string Parameters)
+        public async Task<int> PostJobPositionGetId(object Parameters)
         {
-            string url = $"/api/jobpositions/addjobpositiongetid?{Parameters}";
+            string url = $"/api/jobpositions/addjobpositiongetid";
             using var httpClient = _clientFactory.CreateClient("api");
-            return await httpClient.GetJsonAsync<int>(url);
+            return await httpClient.PostJsonAsync<int>(url, Parameters);
         }
         public async Task PostJobRolePositionCompetency(object Parameters)
         {
             string url = $"/api/jobpositions/addjobrolepositioncompetency?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task PostJobRolePositionLocation(object Parameters)
         {
             string url = $"/api/jobpositions/addjobrolepositionlocation?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task PostJobRolePositionCertificate(object Parameters)
         {
             string url = $"/api/jobpositions/addjobrolepositioncertificate?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task PostJobRolePositionHLCategory(object Parameters)
         {
             string url = $"/api/jobpositions/addjobrolepositionhlcategory?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task PostJobGroupPosition(object Parameters)
         {
             string url = $"/api/jobgroups/addjobgroupposition?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task<JobGroupPositionDto[]> GetJobGroupPositionsById(int Id)
         {
@@ -238,13 +238,13 @@ namespace Admin.Data
         {
             string url = $"/api/jobcompetencies/updatejobcompetency?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task DeleteJobCompetency(object Parameters)
         {
             string url = $"/api/jobcompetencies/deletejobcompetency?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
         public async Task<JobGroupPositionDto[]> GetJobGroupPositionLevelsById(int Id)
         {
@@ -256,7 +256,7 @@ namespace Admin.Data
         {
             string url = $"/api/jobpositions/updatejobposition?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
     }
 }

--- a/Admin/Data/JobPositionService.cs
+++ b/Admin/Data/JobPositionService.cs
@@ -126,28 +126,28 @@ namespace Admin.Data
         {
             string url = $"/api/jobpositions/updatejobposition?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
 
         public async Task DeleteJobPosition(object Parameters)
         {
             string url = $"/api/jobpositions/deletejobposition?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
 
         public async Task UpdateSimilarPositions(object Parameters)
         {
             string url = $"/api/similar/updatesimilarjobpositions?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
 
         public async Task PostSimilarPositions(object Parameters)
         {
             string url = $"/api/similar/addsimilarjobpositions?";
             using var httpClient = _clientFactory.CreateClient("api");
-            await httpClient.PostJsonAsync<HttpResponseMessage>(url, Parameters);
+            await httpClient.PostJsonAsync(url, Parameters);
         }
 
         public async Task<int[]> GetAllSimilarSearchIds()

--- a/Admin/Pages/Certificates/Create.cshtml
+++ b/Admin/Pages/Certificates/Create.cshtml
@@ -11,8 +11,8 @@
 <hr />
 <div class="row">
     <div class="col-md-6">
-        <form method="post">
-            <div asp-validation-summary="ModelOnly" class="text-danger"></div>
+        <form method="post" class="trimFormWhenSubmitting">
+            <span asp-validation-for="Certificate" class="text-danger"></span>
             <div class="form-group">
                 <label asp-for="Certificate.NameEng" class="control-label"></label>
                 <textarea class="form-control" asp-for="Certificate.NameEng" required></textarea>
@@ -25,12 +25,12 @@
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
-                <textarea asp-for="Certificate.DescEng" class="form-control"></textarea>
+                <textarea asp-for="Certificate.DescEng" class="form-control big-textarea"></textarea>
                 <span asp-validation-for="Certificate.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescFre" class="control-label"></label>
-                <textarea asp-for="Certificate.DescFre" class="form-control"></textarea>
+                <textarea asp-for="Certificate.DescFre" class="form-control big-textarea"></textarea>
                 <span asp-validation-for="Certificate.DescFre" class="text-danger"></span>
             </div>
 
@@ -39,6 +39,33 @@
                 <a class="btn btn-secondary" href="/Certificates">Cancel</a>
             </div>
         </form>
+    </div>
+    <div class="col-md-6">
+        <div class="alert alert-primary" role="alert">
+            Note: if the certificate description includes a link, here is how to denote it. Put the URL at the end
+            of the description, and then include the text that will display in place of the link between two sets
+            of three hyphens (---). <br /><br />
+            For example, if you want the link to appear as "<span class="underline">Some College</span>", you would finish the
+            description with something like this: <br /><br /><b>https://SomeExample.com---Some College---</b>
+            <br /><br />
+            If there are multiple links in the description, simply put each link on a separate line, and leave 
+            no blank lines between them. For example: <br /><br />
+
+            <b>https://link1.com---Link 1---<br />
+            https://link2.com---Link 2---<br />
+            https://link3.com---Link 3---<br /></b>
+            <br />
+
+            The links will appear as follows:
+
+            <br /><br />
+
+            <a href="#">Link 1 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
+            <span class="inline-block margin-left-link-spacing">| </span>
+            <a href="#">Link 2 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
+            <span class="inline-block margin-left-link-spacing">| </span>
+            <a href="#">Link 3 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
+        </div>
     </div>
 </div>
 

--- a/Admin/Pages/Certificates/Create.cshtml.cs
+++ b/Admin/Pages/Certificates/Create.cshtml.cs
@@ -1,6 +1,8 @@
 ﻿using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
+using System.Linq;
+using System.Collections.Generic;
 using Admin.Data;
 using Business.Dtos.JobCompetencies;
 using System.Threading;
@@ -29,13 +31,74 @@ namespace Admin.Pages.Certificates
         [BindProperty]
         public int CompetencyType { get; set; }
 
+        private string CheckUniqueCertificateName(JobCertificateDto certificate, bool checkEnglish = true)
+        {
+            if (certificate == null)
+            {
+                return null;
+            }
+
+            var cert = certificate;
+
+            var activeCerts = _context.Certificates.Where(x => x.Id != cert.Id && x.Active == 1).ToList();
+            var inactiveCerts = _context.Certificates.Where(x => x.Id != cert.Id && x.Active == 0).ToList();
+
+            if (checkEnglish)
+            {
+                if (!string.IsNullOrWhiteSpace(cert.NameEng))
+                {
+                    if (activeCerts.Select(x => x.NameEng.ToLowerInvariant()).Contains(cert.NameEng.ToLowerInvariant()))
+                    {
+                        return "A certificate with the same English title already exists";
+                    }
+                    else if (inactiveCerts.Select(x => x.NameEng.ToLowerInvariant()).Contains(cert.NameEng.ToLowerInvariant()))
+                    {
+                        return "A certificate with the same English title already exists, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(cert.NameFre))
+                {
+                    if (activeCerts.Select(x => x.NameFre.ToLowerInvariant()).Contains(cert.NameFre.ToLowerInvariant()))
+                    {
+                        return "A certificate with the same French title already exists";
+                    }
+                    else if (inactiveCerts.Select(x => x.NameFre.ToLowerInvariant()).Contains(cert.NameFre.ToLowerInvariant()))
+                    {
+                        return "A certificate with the same English title already exists, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+
+            return null;
+        }
+
         // To protect from overposting attacks, enable the specific properties you want to bind to, for
         // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
-            var Parameters = $"&nameEng={Certificate.NameEng}&nameFre={Certificate.NameFre}&descEng={Certificate.DescEng}&descFre={Certificate.DescFre}"; 
-            var id = await _jobCertificateService.PostJobCertificate(Parameters);
-            Thread.Sleep(5000);
+            var errEng = CheckUniqueCertificateName(Certificate);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("Certificate.NameEng", errEng);
+            }
+            var errFre = CheckUniqueCertificateName(Certificate, false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("Certificate.NameFre", errFre);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var id = await _jobCertificateService.PostJobCertificate(Certificate);
+
             return RedirectToPage("Details", new { id });
 
         }

--- a/Admin/Pages/Certificates/Delete.cshtml
+++ b/Admin/Pages/Certificates/Delete.cshtml
@@ -1,5 +1,6 @@
 ﻿@page
 @model Admin.Pages.Certificates.DeleteModel
+@inject Admin.Data.FormattingService Formatter
 
 @{
     ViewData["Title"] = "Delete";
@@ -31,7 +32,45 @@
         @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescEng))
         {
             <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.Certificate.DescEng)
+                @{
+                    var descPortions = Model.Certificate.DescEng.Split("\r\n");
+                    bool oneLinkAdded = false;
+                    foreach (var desc in descPortions)
+                    {
+                        bool containsALink = false;
+                        if (desc.Contains("http"))
+                        {
+                            containsALink = true;
+                        }
+                        if (!containsALink)
+                        {
+                            <span>@desc</span>
+                            <br />
+                        }
+                        else
+                        {
+                            var formattedLink = Formatter.FormatCertificateDescriptionLink(desc);
+                            var href = formattedLink[0];
+                            var displayStr = formattedLink[1];
+                            
+                            if (oneLinkAdded)
+                            {
+                                <span class="inline-block margin-left-link-spacing">| </span>
+                            }
+
+                            <a href="@href" target="_blank">
+                                @displayStr
+                                <img src="~/images/icons/external_link_icon.png" 
+                                class="external-link" alt="Open link in new tab" />
+                            </a>
+
+                            if (!oneLinkAdded)
+                            {
+                                oneLinkAdded = true;
+                            }
+                        }
+                    }
+                }
             </dd>
         }
         else
@@ -46,7 +85,44 @@
         @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescFre))
         {
             <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.Certificate.DescFre)
+                @{
+                    var descPortions = Model.Certificate.DescFre.Split("\r\n");
+                    bool oneLinkAdded = false;
+                    foreach (var desc in descPortions)
+                    {
+                        bool containsALink = false;
+                        if (desc.Contains("http"))
+                        {
+                            containsALink = true;
+                        }
+                        if (!containsALink)
+                        {
+                            <span>@desc</span>
+                            <br />
+                        }
+                        else
+                        {
+                            var formattedLink = Formatter.FormatCertificateDescriptionLink(desc);
+                            var href = formattedLink[0];
+                            var displayStr = formattedLink[1];
+
+                            if (oneLinkAdded)
+                            {
+                                <span class="inline-block margin-left-link-spacing">| </span>
+                            }
+                            <a href="@href" target="_blank">
+                                @displayStr
+                                <img src="~/images/icons/external_link_icon.png" 
+                                class="external-link" alt="Open link in new tab" />
+                            </a>
+
+                            if (!oneLinkAdded)
+                            {
+                                oneLinkAdded = true;
+                            }
+                        }
+                    }
+                }
             </dd>
         }
         else

--- a/Admin/Pages/Certificates/Delete.cshtml.cs
+++ b/Admin/Pages/Certificates/Delete.cshtml.cs
@@ -67,19 +67,14 @@ namespace Admin.Pages.Certificates
             {
                 return NotFound();
             }
+            if (Certificate.Active != 1)
+            {
+                return NotFound();
+            }
 
-            try
-            {
-                _jobCertificateService.DeleteJobCertificate(Certificate);
-                Thread.Sleep(5000);
-                return RedirectToPage("./Index");
-            }
-            catch (DbUpdateException ex)
-            {
-                _logger.LogError(ex, ErrorMessage);
-                return RedirectToAction("./Delete",
-                                     new { id, saveChangesError = true });
-            }
+            await _jobCertificateService.DeleteJobCertificate(Certificate);
+
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/Admin/Pages/Certificates/Descriptions/Create.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Create.cshtml
@@ -9,10 +9,10 @@
 <h4>Certificate Description</h4>
 <hr />
 <div class="row">
-    <div class="col-md-4">
-        <form method="post">
+    <div class="col-md-6">
+        <form method="post" class="trimFormWhenSubmitting">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-            <input type="hidden" asp-for="Certificate.Id" />
+
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
                 <textarea asp-for="Certificate.DescEng" class="form-control" required></textarea>

--- a/Admin/Pages/Certificates/Descriptions/Create.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Create.cshtml.cs
@@ -5,6 +5,8 @@ using DataModel;
 using Admin.Data;
 using Microsoft.Extensions.Logging;
 using System.Threading;
+using System.Linq;
+using System.Collections.Generic;
 
 namespace Admin.Pages.Certificates.Descriptions
 {
@@ -26,16 +28,73 @@ namespace Admin.Pages.Certificates.Descriptions
         [BindProperty]
         public CertificateDescription Certificate { get; set; }
 
-        [BindProperty]
-        public int CompetencyType { get; set; }
+        private string CheckUniqueCertificateDescription(CertificateDescription description, bool checkEnglish = true)
+        {
+            if (description == null)
+            {
+                return null;
+            }
+
+            var desc = description;
+
+            var activeDescs = _context.CertificateDescriptions.Where(x => x.Id != desc.Id && x.Active == 1).ToList();
+            var inactiveDescs = _context.CertificateDescriptions.Where(x => x.Id != desc.Id && x.Active == 0).ToList();
+
+            if (checkEnglish)
+            {
+                if (!string.IsNullOrWhiteSpace(desc.DescEng))
+                {
+                    if (activeDescs.Select(x => x.DescEng.ToLowerInvariant()).Contains(desc.DescEng.ToLowerInvariant()))
+                    {
+                        return "That English certificate description already exists";
+                    }
+                    else if (inactiveDescs.Select(x => x.DescEng.ToLowerInvariant()).Contains(desc.DescEng.ToLowerInvariant()))
+                    {
+                        return "There English certificate description already exists, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(desc.DescFre))
+                {
+                    if (activeDescs.Select(x => x.DescFre.ToLowerInvariant()).Contains(desc.DescFre.ToLowerInvariant()))
+                    {
+                        return "That French certificate description already exists";
+                    }
+                    else if (inactiveDescs.Select(x => x.DescFre.ToLowerInvariant()).Contains(desc.DescFre.ToLowerInvariant()))
+                    {
+                        return "That French certificate description already exists, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+
+            return null;
+        }
 
         // To protect from overposting attacks, enable the specific properties you want to bind to, for
         // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
+            var errEng = CheckUniqueCertificateDescription(Certificate);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("Certificate.DescEng", errEng);
+            }
+            var errFre = CheckUniqueCertificateDescription(Certificate, false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("Certificate.DescFre", errFre);
+            }
 
-            var id = await _jobCertificateService.PostJobCertificateDescription(Certificate.DescEng, Certificate.DescFre);
-            Thread.Sleep(5000);
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var id = await _jobCertificateService.PostJobCertificateDescription(Certificate);
             return RedirectToPage("Details", new { id });
 
         }

--- a/Admin/Pages/Certificates/Descriptions/Delete.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Delete.cshtml.cs
@@ -74,19 +74,14 @@ namespace Admin.Pages.Certificates.Descriptions
             {
                 return NotFound();
             }
+            if (Certificate.Active != 1)
+            {
+                return NotFound();
+            }
 
-            try
-            {
-                _jobCertificateService.DeleteJobCertificateDescription(Certificate);
-                Thread.Sleep(5000);
-                return RedirectToPage("./Index");
-            }
-            catch (DbUpdateException ex)
-            {
-                _logger.LogError(ex, ErrorMessage);
-                return RedirectToAction("./Delete",
-                                     new { id, saveChangesError = true });
-            }
+            await _jobCertificateService.DeleteJobCertificateDescription(Certificate);
+
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/Admin/Pages/Certificates/Descriptions/Details.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Details.cshtml
@@ -26,6 +26,8 @@
 </div>
 <div>
     <a asp-page="./Edit" asp-route-id="@Model.Description.Id">Edit</a> |
-    <a asp-page="./Index">Back to List</a>
+    <a asp-page="./Index">Back to List</a> |
+    <a asp-page="./Locate" asp-route-id="@Model.Description.Id">Locate</a> |
+    <a asp-page="./Delete" asp-route-id="@Model.Description.Id">Delete</a>
 </div>
 

--- a/Admin/Pages/Certificates/Descriptions/Edit.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Edit.cshtml
@@ -10,7 +10,7 @@
 <hr />
 <div class="row">
     <div class="col-md-6">
-        <form method="post">
+        <form method="post" class="trimFormWhenSubmitting">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Certificate.Id" />
             <div class="form-group">

--- a/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
@@ -4,7 +4,9 @@ using Microsoft.AspNetCore.Mvc.RazorPages;
 using DataModel;
 using Microsoft.Extensions.Logging;
 using Admin.Data;
+using System.Linq;
 using System.Threading;
+using System;
 
 namespace Admin.Pages.Certificates.Descriptions
 {
@@ -25,6 +27,52 @@ namespace Admin.Pages.Certificates.Descriptions
 
         [BindProperty]
         public CertificateDescription Certificate { get; set; }
+
+        private string CheckUniqueCertificateDescription(CertificateDescription description, bool checkEnglish = true)
+        {
+            if (description == null)
+            {
+                return null;
+            }
+
+            var desc = description;
+
+            var activeDescs = _context.CertificateDescriptions.Where(x => x.Id != desc.Id && x.Active == 1).ToList();
+            var inactiveDescs = _context.CertificateDescriptions.Where(x => x.Id != desc.Id && x.Active == 0).ToList();
+
+            if (checkEnglish)
+            {
+                if (!string.IsNullOrWhiteSpace(desc.DescEng))
+                {
+                    if (activeDescs.Select(x => x.DescEng.ToLowerInvariant()).Contains(desc.DescEng.ToLowerInvariant()))
+                    {
+                        return "That English certificate description already exists";
+                    }
+                    else if (inactiveDescs.Select(x => x.DescEng.ToLowerInvariant()).Contains(desc.DescEng.ToLowerInvariant()))
+                    {
+                        return "There English certificate description already exists, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(desc.DescFre))
+                {
+                    if (activeDescs.Select(x => x.DescFre.ToLowerInvariant()).Contains(desc.DescFre.ToLowerInvariant()))
+                    {
+                        return "That French certificate description already exists";
+                    }
+                    else if (inactiveDescs.Select(x => x.DescFre.ToLowerInvariant()).Contains(desc.DescFre.ToLowerInvariant()))
+                    {
+                        return "That French certificate description already exists, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+
+            return null;
+        }
 
         public async Task<IActionResult> OnGetAsync(int? id)
         {
@@ -57,6 +105,22 @@ namespace Admin.Pages.Certificates.Descriptions
         // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync(int id)
         {
+            var errEng = CheckUniqueCertificateDescription(Certificate);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("Certificate.DescEng", errEng);
+            }
+            var errFre = CheckUniqueCertificateDescription(Certificate, false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("Certificate.DescFre", errFre);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
             var certificateToUpdate = await _context.CertificateDescriptions.FindAsync(id);
 
             if (certificateToUpdate == null)
@@ -69,8 +133,8 @@ namespace Admin.Pages.Certificates.Descriptions
                 "certificate",
                 s => s.DescEng, s => s.DescFre))
             {
-                _jobCertificateService.UpdateJobCertificateDescription(Certificate);
-                Thread.Sleep(5000);
+                await _jobCertificateService.UpdateJobCertificateDescription(Certificate);
+
                 return RedirectToPage("Details", new { id });
             }
 

--- a/Admin/Pages/Certificates/Descriptions/Index.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Index.cshtml
@@ -51,7 +51,7 @@
 
 @if (itemsThatMatchFilter.Any())
 {
-    <div id="table-container">
+    <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
           <table class="table">
                 <thead>
                     <tr class="table-header-row text-center">

--- a/Admin/Pages/Certificates/Descriptions/Index.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Index.cshtml
@@ -5,11 +5,11 @@
 }
 
 <div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
-    <h1>Certificate Descriptions</h1>
+    <h1>Certificate Descriptions <span class="glyphicon glyphicon-save-file pull-right index-save-file-icon" onclick="print()"></span></h1>
 
-    <p class="space-btns">
+    <p class="space-btns hide-in-print">
         <a class="btn btn-dark" asp-page="Create">Create New</a>    
-        <a class="btn btn-info pull-right" href="/Certificates/Descriptions">Certificate Descriptions</a>
+        <a class="btn btn-info pull-right index-right-button" href="/Certificates/Descriptions">Certificate Descriptions</a>
         <a class="btn btn-secondary pull-right" href="/Certificates">Certificates</a>
     </p>
 
@@ -29,7 +29,7 @@
         itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.DescEng.ToLower()).ToList();
     }
 
-    <form>
+    <form class="hide-in-print">
         <div class="form-actions no-color">
             <h6>
                 <label for="Filter">Find certificate descriptions:</label>
@@ -39,6 +39,11 @@
                 {
                     <span><span class="vertical-bar">|</span> <a asp-page="./Index">Back to Full List</a></span>
                 }
+
+                <a class="pull-right index-right-button" href="/Certificates/Descriptions/Locate"
+                title="Find out which jobs/certificates have the specified certificate description" data-toggle="tooltip">
+                    Locate Descriptions
+                </a>
             </h6>
         </div>
     </form>
@@ -50,11 +55,11 @@
           <table class="table">
                 <thead>
                     <tr class="table-header-row text-center">
-                        <th><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate Description English</b></th>
-                        <th><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate Description French</b></th>
-                        <th>
+                        <th class="col-5"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate Description English</b></th>
+                        <th class="col-5"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate Description French</b></th>
+                        <th class="col-2">
                             <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
-                            class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop"
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop"
                             aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
                             alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                             title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
@@ -71,10 +76,13 @@
                             <td>
                                 @Html.DisplayFor(modelItem => item.DescFre)
                             </td>
-                            <td style="width:15%">
+                            <td class="hide-in-print text-center">
                                 <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
                                 <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
                                 <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                            </td>
+                            <td class="hide-when-not-in-print table-cell text-center col-2">
+                                <a asp-page="./Details" asp-route-id="@item.Id" class="print-link underline">Details</a>
                             </td>
                         </tr>
                     }

--- a/Admin/Pages/Certificates/Descriptions/Index.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Index.cshtml.cs
@@ -23,9 +23,12 @@ namespace Admin.Pages.Certificates.Descriptions
         public string Filter { get; set; }
 
         public bool DisplayTopOfPage { get; set; }
+
+        public double LastTableContainerHeight { get; set; } = 300;
+
         public IList<JobCertificateDto> Descriptions { get; set; }
 
-        public async Task OnGetAsync(string searchString)
+        public async Task OnGetAsync()
         {
             Descriptions = await _jobCertificateService.GetAllJobCertificateDescriptions();
 
@@ -36,6 +39,17 @@ namespace Admin.Pages.Certificates.Descriptions
                 if (sessionStr.ToLower() == "false")
                 {
                     DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
                 }
             }
         }

--- a/Admin/Pages/Certificates/Details.cshtml
+++ b/Admin/Pages/Certificates/Details.cshtml
@@ -1,5 +1,6 @@
 ﻿@page
 @model Admin.Pages.Certificates.DetailsModel
+@inject Admin.Data.FormattingService Formatter
 
 @{
     ViewData["Title"] = "Details";
@@ -29,7 +30,45 @@
         @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescEng))
         {
             <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.Certificate.DescEng)
+                @{
+                    var descPortions = Model.Certificate.DescEng.Split("\r\n");
+                    bool oneLinkAdded = false;
+                    foreach (var desc in descPortions)
+                    {
+                        bool containsALink = false;
+                        if (desc.Contains("http"))
+                        {
+                            containsALink = true;
+                        }
+                        if (!containsALink)
+                        {
+                            <span>@desc</span>
+                            <br />
+                        }
+                        else
+                        {
+                            var formattedLink = Formatter.FormatCertificateDescriptionLink(desc);
+                            var href = formattedLink[0];
+                            var displayStr = formattedLink[1];
+                            
+                            if (oneLinkAdded)
+                            {
+                                <span class="inline-block margin-left-link-spacing">| </span>
+                            }
+
+                            <a href="@href" target="_blank">
+                                @displayStr
+                                <img src="~/images/icons/external_link_icon.png" 
+                                class="external-link" alt="Open link in new tab" />
+                            </a>
+
+                            if (!oneLinkAdded)
+                            {
+                                oneLinkAdded = true;
+                            }
+                        }
+                    }
+                }
             </dd>
         }
         else
@@ -44,7 +83,44 @@
         @if (!string.IsNullOrWhiteSpace(Model.Certificate.DescFre))
         {
             <dd class="col-sm-10">
-                @Html.DisplayFor(model => model.Certificate.DescFre)
+                @{
+                    var descPortions = Model.Certificate.DescFre.Split("\r\n");
+                    bool oneLinkAdded = false;
+                    foreach (var desc in descPortions)
+                    {
+                        bool containsALink = false;
+                        if (desc.Contains("http"))
+                        {
+                            containsALink = true;
+                        }
+                        if (!containsALink)
+                        {
+                            <span>@desc</span>
+                            <br />
+                        }
+                        else
+                        {
+                            var formattedLink = Formatter.FormatCertificateDescriptionLink(desc);
+                            var href = formattedLink[0];
+                            var displayStr = formattedLink[1];
+
+                            if (oneLinkAdded)
+                            {
+                                <span class="inline-block margin-left-link-spacing">| </span>
+                            }
+                            <a href="@href" target="_blank">
+                                @displayStr
+                                <img src="~/images/icons/external_link_icon.png" 
+                                class="external-link" alt="Open link in new tab" />
+                            </a>
+
+                            if (!oneLinkAdded)
+                            {
+                                oneLinkAdded = true;
+                            }
+                        }
+                    }
+                }
             </dd>
         }
         else
@@ -55,7 +131,10 @@
         }
     </dl>
 </div>
+
 <div>
     <a asp-page="./Edit" asp-route-id="@Model.Certificate.Id">Edit</a> |
-    <a asp-page="./Index">Back to List</a>
+    <a asp-page="./Index">Back to List</a> |
+    <a asp-page="./Locate" asp-route-id="@Model.Certificate.Id">Locate</a> |
+    <a asp-page="./Delete" asp-route-id="@Model.Certificate.Id">Delete</a>
 </div>

--- a/Admin/Pages/Certificates/Edit.cshtml
+++ b/Admin/Pages/Certificates/Edit.cshtml
@@ -59,7 +59,8 @@
 
             The links will appear as follows:
 
-            <br /><br />
+            <br />
+            <br />
 
             <a href="#">Link 1 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
             <span class="inline-block margin-left-link-spacing">| </span>

--- a/Admin/Pages/Certificates/Edit.cshtml
+++ b/Admin/Pages/Certificates/Edit.cshtml
@@ -11,7 +11,7 @@
 <hr />
 <div class="row">
     <div class="col-md-6">
-        <form method="post">
+        <form method="post" class="trimFormWhenSubmitting">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Certificate.Id" />
             <div class="form-group">
@@ -26,12 +26,12 @@
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescEng" class="control-label"></label>
-                <textarea asp-for="Certificate.DescEng" class="form-control"></textarea>
+                <textarea asp-for="Certificate.DescEng" class="form-control big-textarea"></textarea>
                 <span asp-validation-for="Certificate.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Certificate.DescFre" class="control-label"></label>
-                <textarea asp-for="Certificate.DescFre" class="form-control"></textarea>
+                <textarea asp-for="Certificate.DescFre" class="form-control big-textarea"></textarea>
                 <span asp-validation-for="Certificate.DescFre" class="text-danger"></span>
             </div>
 
@@ -40,6 +40,33 @@
                 <a class="btn btn-secondary" href="/Certificates/Details?id=@Model.Certificate.Id">Cancel</a>
             </div>
         </form>
+    </div>
+    <div class="col-md-6">
+        <div class="alert alert-primary" role="alert">
+            Note: if the certificate description includes a link, here is how to denote it. Put the URL at the end
+            of the description, and then include the text that will display in place of the link between two sets
+            of three hyphens (---). <br /><br />
+            For example, if you want the link to appear as "<span class="underline">Some College</span>", you would finish the
+            description with something like this: <br /><br /><b>https://SomeExample.com---Some College---</b>
+            <br /><br />
+            If there are multiple links in the description, simply put each link on a separate line, and leave 
+            no blank lines between them. For example: <br /><br />
+
+            <b>https://link1.com---Link 1---<br />
+            https://link2.com---Link 2---<br />
+            https://link3.com---Link 3---<br /></b>
+            <br />
+
+            The links will appear as follows:
+
+            <br /><br />
+
+            <a href="#">Link 1 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
+            <span class="inline-block margin-left-link-spacing">| </span>
+            <a href="#">Link 2 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
+            <span class="inline-block margin-left-link-spacing">| </span>
+            <a href="#">Link 3 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a>
+        </div>
     </div>
 </div>
 

--- a/Admin/Pages/Certificates/Edit.cshtml.cs
+++ b/Admin/Pages/Certificates/Edit.cshtml.cs
@@ -40,7 +40,6 @@ namespace Admin.Pages.Certificates
             }
 
             Certificate = await _context.Certificates.FindAsync(id);
-
             if (Certificate == null)
             {
                 return NotFound();

--- a/Admin/Pages/Certificates/Index.cshtml
+++ b/Admin/Pages/Certificates/Index.cshtml
@@ -51,7 +51,7 @@
 
 @if (itemsThatMatchFilter.Any())
 {
-    <div id="table-container">
+    <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">

--- a/Admin/Pages/Certificates/Index.cshtml
+++ b/Admin/Pages/Certificates/Index.cshtml
@@ -6,11 +6,11 @@
 }
 
 <div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
-    <h1>Certificates</h1>
+    <h1>Certificates <span class="glyphicon glyphicon-save-file pull-right index-save-file-icon" onclick="print()"></span></h1>
 
-    <p class="space-btns">
+    <p class="space-btns hide-in-print">
         <a class="btn btn-dark" asp-page="Create">Create New</a>
-        <a class="btn btn-secondary pull-right" href="/Certificates/Descriptions">Certificate Descriptions</a>
+        <a class="btn btn-secondary pull-right index-right-button" href="/Certificates/Descriptions">Certificate Descriptions</a>
         <a class="btn btn-info pull-right" href="/Certificates">Certificates</a>
     </p>
 
@@ -29,7 +29,7 @@
         itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.NameEng.ToLower()).ToList();
     }
 
-    <form>
+    <form class="hide-in-print">
         <div class="form-actions no-color">
             <h6>
                 <label for="Filter">Find certificates:</label>
@@ -39,6 +39,11 @@
                 {
                     <span><span class="vertical-bar">|</span> <a asp-page="./Index">Back to Full List</a></span>
                 }
+
+                <a class="pull-right index-right-button" href="/Certificates/Locate"
+                title="Find out which jobs require the specified certificate" data-toggle="tooltip">
+                    Locate Certificates
+                </a>
             </h6>
         </div>
     </form>
@@ -50,11 +55,11 @@
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">
-                    <th><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate English</b></th>
-                    <th><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate French</b></th>
-                    <th>
+                    <th class="col-5"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate English</b></th>
+                    <th class="col-5"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate French</b></th>
+                    <th class="col-2">
                         <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
-                        class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
+                        class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
                         aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
                         alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                         title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
@@ -71,10 +76,13 @@
                         <td>
                             @Html.DisplayFor(modelItem => item.NameFre)
                         </td>
-                        <td style="width:15%">
+                        <td class="hide-in-print text-center">
                             <a asp-page="./Details" asp-route-id="@item.Id">Details</a> |
                             <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a> |
                             <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                        </td>
+                        <td class="hide-when-not-in-print table-cell text-center col-2">
+                            <a asp-page="./Details" asp-route-id="@item.Id" class="print-link underline">Details</a>
                         </td>
                     </tr>
                 }

--- a/Admin/Pages/Certificates/Index.cshtml.cs
+++ b/Admin/Pages/Certificates/Index.cshtml.cs
@@ -28,6 +28,8 @@ namespace Admin.Pages.Certificates
 
         public bool DisplayTopOfPage { get; set; }
 
+        public double LastTableContainerHeight { get; set; } = 300;
+
         public IList<JobCertificateDto> Certificates { get; set; }
 
         public async Task OnGetAsync(string searchString)
@@ -41,6 +43,17 @@ namespace Admin.Pages.Certificates
                 if (sessionStr.ToLower() == "false")
                 {
                     DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
                 }
             }
         }

--- a/Admin/Pages/Competencies/Create.cshtml
+++ b/Admin/Pages/Competencies/Create.cshtml
@@ -10,18 +10,18 @@
 <hr />
 
 <div class="col-md-12">
-    <form method="post">
+    <form method="post" class="trimFormWhenSubmitting">
         <div asp-validation-summary="ModelOnly" class="text-danger"></div>
         <h3 style="margin-bottom:15px;">Choose the competency type</h3>
         <div class="form-group">
-            <input type="radio" id="knowledge" asp-for="@Model.TypeId" name="CompetencyType" value="1">
-            <label class="h5 mr-md-3" asp-for="@Model.TypeId" for="knowledge">Knowledge</label>
-            <input type="radio" id="technical" asp-for="@Model.TypeId" name="CompetencyType" value="2">
-            <label class="h5 mr-md-3" asp-for="@Model.TypeId" for="technical">Technical</label>
-            <input type="radio" id="behavioural" asp-for="@Model.TypeId" name="CompetencyType" value="3">
-            <label class="h5 mr-md-3" asp-for="@Model.TypeId" for="behavioural">Behavioural</label>
-            <input type="radio" id="executive" asp-for="@Model.TypeId" name="CompetencyType" value="4">
-            <label class="h5 mr-md-3" asp-for="@Model.TypeId" for="executive">Executive</label>
+            <input type="radio" id="knowledge" asp-for="@Model.TypeId" value="1">
+            <label class="h5 mr-md-3" for="knowledge">Knowledge</label>
+            <input type="radio" id="technical" asp-for="@Model.TypeId" value="2">
+            <label class="h5 mr-md-3" for="technical">Technical</label>
+            <input type="radio" id="behavioural" asp-for="@Model.TypeId" value="3">
+            <label class="h5 mr-md-3" for="behavioural">Behavioural</label>
+            <input type="radio" id="executive" asp-for="@Model.TypeId" value="4">
+            <label class="h5 mr-md-3" for="executive">Executive</label>
         </div>
         <div class="form-group">
             <label asp-for="Competency.NameEng" class="control-label"><b>Name English</b></label>
@@ -35,12 +35,12 @@
         </div>
         <div class="form-group">
             <label asp-for="Competency.DescEng" class="control-label"><b>Description English</b></label>
-            <textarea asp-for="Competency.DescEng" class="form-control" rows="5" cols="50"></textarea>
+            <textarea asp-for="Competency.DescEng" class="form-control" rows="5" cols="50" required></textarea>
             <span asp-validation-for="Competency.DescEng" class="text-danger"></span>
         </div>
         <div class="form-group">
             <label asp-for="Competency.DescFre" class="control-label"><b>Description French</b></label>
-            <textarea asp-for="Competency.DescFre" class="form-control" rows="5" cols="50"></textarea>
+            <textarea asp-for="Competency.DescFre" class="form-control" rows="5" cols="50" required></textarea>
             <span asp-validation-for="Competency.DescFre" class="text-danger"></span>
         </div>
 
@@ -49,60 +49,60 @@
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 1 - English</b></label>
-                <textarea asp-for="Competency.Level1DescEng" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level1DescEng" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level1DescEng" class="text-danger"></span>
             </div>
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 1 - French</b></label>
-                <textarea asp-for="Competency.Level1DescFre" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level1DescFre" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level1DescFre" class="text-danger"></span>
             </div>
         </div>
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level2DescEng" class="control-label"><b>Level 2 - English</b></label>
-                <textarea asp-for="Competency.Level2DescEng" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level2DescEng" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level2DescEng" class="text-danger"></span>
             </div>
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level2DescFre" class="control-label"><b>Level 2 - French</b></label>
-                <textarea asp-for="Competency.Level2DescFre" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level2DescFre" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level2DescFre" class="text-danger"></span>
             </div>
         </div>
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level3DescEng" class="control-label"><b>Level 3 - English</b></label>
-                <textarea asp-for="Competency.Level3DescEng" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level3DescEng" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level3DescEng" class="text-danger"></span>
             </div>
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level3DescFre" class="control-label"><b>Level 3 - French</b></label>
-                <textarea asp-for="Competency.Level3DescFre" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level3DescFre" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level3DescFre" class="text-danger"></span>
             </div>
         </div>
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level4DescEng" class="control-label"><b>Level 4 - English</b></label>
-                <textarea asp-for="Competency.Level4DescEng" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level4DescEng" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level4DescEng" class="text-danger"></span>
             </div>
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level4DescFre" class="control-label"><b>Level 4 - French</b></label>
-                <textarea asp-for="Competency.Level4DescFre" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level4DescFre" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level2DescFre" class="text-danger"></span>
             </div>
         </div>
         <div class="row">
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level5DescEng" class="control-label"><b>Level 5 - English</b></label>
-                <textarea asp-for="Competency.Level5DescEng" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level5DescEng" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level5DescEng" class="text-danger"></span>
             </div>
             <div class="form-group col-md-6">
                 <label asp-for="Competency.Level5DescFre" class="control-label"><b>Level 5 - French</b></label>
-                <textarea asp-for="Competency.Level5DescFre" class="form-control" rows="3" cols="45"></textarea>
+                <textarea asp-for="Competency.Level5DescFre" class="form-control" rows="3" cols="45" required></textarea>
                 <span asp-validation-for="Competency.Level5DescFre" class="text-danger"></span>
             </div>
         </div>

--- a/Admin/Pages/Competencies/Create.cshtml.cs
+++ b/Admin/Pages/Competencies/Create.cshtml.cs
@@ -28,8 +28,8 @@ namespace Admin.Pages.Competencies
             }
             else
             {
-                int[] typeids = { 1, 2, 3, 4 };
-                if (!typeids.Contains(typeid.Value))
+                var accepetedTypeIds = _context.CompetencyTypes.Select(c => c.Id).ToList();
+                if (!accepetedTypeIds.Contains(typeid.Value))
                 {
                     return Redirect("/Competencies/Create?typeid=1");
                 }
@@ -44,16 +44,87 @@ namespace Admin.Pages.Competencies
         public int TypeId { get; set; }
 
         [BindProperty]
-        public int CompetencyType { get; set; } 
+        public int CompetencyType { get; set; }
+
+        private string CheckUniqueCompetencyName(JobCompetencyDto competency, int typeId, bool checkEnglish = true)
+        {
+            if (competency == null)
+            {
+                return null;
+            }
+
+            var comp = competency;
+
+            var compTypeName = _context.CompetencyTypes.Where(x => x.Id == typeId).FirstOrDefault().NameEng.ToLower();
+            if (compTypeName.Contains("ies"))
+            {
+                compTypeName = compTypeName.Replace("ies", "yX");
+            }
+            compTypeName = compTypeName[..^1];
+
+            var competencyIdsOfType = _context.CompetencyTypeGroups.Where(x => x.CompetencyTypeId == typeId)
+                .Select(x => x.CompetencyId).ToList();
+
+            var activeComps = _context.Competencies.Where(x => x.Id != comp.Id && competencyIdsOfType.Contains(x.Id) && x.Active == 1).ToList();
+            var inactiveComps = _context.Competencies.Where(x => x.Id != comp.Id && competencyIdsOfType.Contains(x.Id) && x.Active == 0).ToList();
+
+            if (checkEnglish)
+            {
+                if (!string.IsNullOrWhiteSpace(comp.NameEng))
+                {
+                    if (activeComps.Select(x => x.NameEng.ToLowerInvariant()).Contains(comp.NameEng.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that English name";
+                    }
+                    else if (inactiveComps.Select(x => x.NameEng.ToLowerInvariant()).Contains(comp.NameEng.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that English name, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(comp.NameFre))
+                {
+                    if (activeComps.Select(x => x.NameFre.ToLowerInvariant()).Contains(comp.NameFre.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that French name";
+                    }
+                    else if (inactiveComps.Select(x => x.NameFre.ToLowerInvariant()).Contains(comp.NameFre.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that French name, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+
+            return null;
+        }
 
         // To protect from overposting attacks, enable the specific properties you want to bind to, for
         // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
-            Competency.TypeId = CompetencyType;
-            var parameters = string.Format($"&typeId={Competency.TypeId}&nameEng={Competency.NameEng}&nameFre={Competency.NameFre}&descEng={Competency.DescEng}&descFre={Competency.DescFre}&level1DescEng={Competency.Level1DescEng}&level1DescFre={Competency.Level1DescFre}&level2DescEng={Competency.Level2DescEng}&level2DescFre={Competency.Level2DescFre}&level3DescEng={Competency.Level3DescEng}&level3DescFre={Competency.Level3DescFre}&level4DescEng={Competency.Level4DescEng}&level4DescFre={Competency.Level4DescFre}&level5DescEng={Competency.Level5DescEng}&level5DescFre={Competency.Level5DescFre}");
-            var competencyid = await _jobCompetencyService.PostJobCompetency(parameters);
-            Thread.Sleep(5000);
+            var errEng = CheckUniqueCompetencyName(Competency, TypeId);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("Competency.NameEng", errEng);
+            }
+            var errFre = CheckUniqueCompetencyName(Competency, TypeId,false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("Competency.NameFre", errFre);
+            }
+
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            Competency.TypeId = TypeId;
+            var competencyid = await _jobCompetencyService.PostJobCompetency(Competency);
+
             return RedirectToPage("Details", new { id = competencyid});
 
         }

--- a/Admin/Pages/Competencies/Delete.cshtml.cs
+++ b/Admin/Pages/Competencies/Delete.cshtml.cs
@@ -69,6 +69,17 @@ namespace Admin.Pages.Competencies
                 return NotFound();
             }
 
+            var compExists = await _context.Competencies.FindAsync(id);
+
+            if (compExists == null)
+            {
+                return NotFound();
+            }
+            if (compExists.Active != 1)
+            {
+                return NotFound();
+            }
+
             Competency = await _jobCompetencyService.GetJobCompetencyById(id);
 
             if (Competency == null)
@@ -76,19 +87,9 @@ namespace Admin.Pages.Competencies
                 return NotFound();
             }
 
-            try
-            {
-                _jobCompetencyService.DeleteJobCompetency(Competency);
-                Thread.Sleep(5000);
-                return RedirectToPage("./List", new { typeId = Competency.TypeId });
-            }
-            catch (DbUpdateException ex)
-            {
-                _logger.LogError(ex, ErrorMessage);
+            await _jobCompetencyService.DeleteJobCompetency(Competency);
 
-                return RedirectToAction("./Delete",
-                                           new { id, saveChangesError = true });
-            }
+            return RedirectToPage("./List", new { typeId = Competency.TypeId });
         }
     }
 }

--- a/Admin/Pages/Competencies/Details.cshtml
+++ b/Admin/Pages/Competencies/Details.cshtml
@@ -101,5 +101,7 @@
 
 <div>
     <a asp-page="./Edit" asp-route-id="@Model.Competency.Id">Edit</a> |
-    <a asp-page="./List" asp-route-typeid="@Model.Competency.TypeId">Back to List</a>
+    <a asp-page="./List" asp-route-typeid="@Model.Competency.TypeId">Back to List</a> |
+    <a asp-page="./Locate" asp-route-id="@Model.Competency.Id">Locate</a> |
+    <a asp-page="./Delete" asp-route-id="@Model.Competency.Id">Delete</a>
 </div>

--- a/Admin/Pages/Competencies/Details.cshtml.cs
+++ b/Admin/Pages/Competencies/Details.cshtml.cs
@@ -44,93 +44,9 @@ namespace Admin.Pages.Competencies
 
             Competency = await _jobCompetencyService.GetJobCompetencyById(id);
 
-            try
+            if (Competency == null)
             {
-                Competency.Level1DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level1DescEng = "";
-            }
-            try
-            {
-                Competency.Level1DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level1DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level2DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level2DescEng = "";
-            }
-            try
-            {
-                Competency.Level2DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level2DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level3DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level3DescEng = "";
-            }
-            try
-            {
-                Competency.Level3DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level3DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level4DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level4DescEng = "";
-            }
-            try
-            {
-                Competency.Level4DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level4DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level5DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level5DescEng = "";
-            }
-            try
-            {
-                Competency.Level5DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level5DescFre = "";
+                return NotFound();
             }
 
             return Page();

--- a/Admin/Pages/Competencies/Edit.cshtml
+++ b/Admin/Pages/Competencies/Edit.cshtml
@@ -10,87 +10,90 @@
 <hr />
 <div class="row">
     <div class="col-md-12">
-        <form method="post">
+        <form method="post" class="trimFormWhenSubmitting">
             <div asp-validation-summary="ModelOnly" class="text-danger"></div>
             <input type="hidden" asp-for="Competency.Id" />
             <input type="hidden" asp-for="Competency.TypeId" />
             <div class="form-group">
                 <label asp-for="Competency.NameEng" class="control-label"><b>Name English</b></label>
-                <input asp-for="Competency.NameEng" class="form-control" />
+                <input asp-for="Competency.NameEng" class="form-control" required />
                 <span asp-validation-for="Competency.NameEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Competency.NameFre" class="control-label"><b>Name French</b></label>
-                <input asp-for="Competency.NameFre" class="form-control" />
+                <input asp-for="Competency.NameFre" class="form-control" required />
                 <span asp-validation-for="Competency.NameFre" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Competency.DescEng" class="control-label"><b>Description English</b></label>
-                <textarea asp-for="Competency.DescEng" class="form-control" rows="6" cols="50"></textarea>
+                <textarea asp-for="Competency.DescEng" class="form-control" rows="6" cols="50" required></textarea>
                 <span asp-validation-for="Competency.DescEng" class="text-danger"></span>
             </div>
             <div class="form-group">
                 <label asp-for="Competency.DescFre" class="control-label"><b>Description French</b></label>
-                <textarea asp-for="Competency.DescFre" class="form-control" rows="6" cols="50"></textarea>
+                <textarea asp-for="Competency.DescFre" class="form-control" rows="6" cols="50" required></textarea>
                 <span asp-validation-for="Competency.DescFre" class="text-danger"></span>
             </div>
+
+            <h3 class="small-margin-bottom small-margin-top">Edit the descriptions for each level</h3>
+
             <div class="row">
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level1DescEng" class="control-label"><b>Level 1 - English</b></label>
-                    <textarea asp-for="Competency.Level1DescEng" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level1DescEng" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level1DescEng" class="text-danger"></span>
                 </div>
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level1DescFre" class="control-label"><b>Level 1 - French</b></label>
-                    <textarea asp-for="Competency.Level1DescFre" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level1DescFre" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level1DescFre" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level2DescEng" class="control-label"><b>Level 2 - English</b></label>
-                    <textarea asp-for="Competency.Level2DescEng" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level2DescEng" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level2DescEng" class="text-danger"></span>
                 </div>
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level2DescFre" class="control-label"><b>Level 2 - French</b></label>
-                    <textarea asp-for="Competency.Level2DescFre" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level2DescFre" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level2DescFre" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level3DescEng" class="control-label"><b>Level 3 - English</b></label>
-                    <textarea asp-for="Competency.Level3DescEng" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level3DescEng" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level3DescEng" class="text-danger"></span>
                 </div>
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level3DescFre" class="control-label"><b>Level 3 - French</b></label>
-                    <textarea asp-for="Competency.Level3DescFre" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level3DescFre" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level3DescFre" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level4DescEng" class="control-label"><b>Level 4 - English</b></label>
-                    <textarea asp-for="Competency.Level4DescEng" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level4DescEng" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level4DescEng" class="text-danger"></span>
                 </div>
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level4DescFre" class="control-label"><b>Level 4 - French</b></label>
-                    <textarea asp-for="Competency.Level4DescFre" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level4DescFre" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level4DescFre" class="text-danger"></span>
                 </div>
             </div>
             <div class="row">
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level5DescEng" class="control-label"><b>Level 5 - English</b></label>
-                    <textarea asp-for="Competency.Level5DescEng" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level5DescEng" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level5DescEng" class="text-danger"></span>
                 </div>
                 <div class="form-group col-md-6">
                     <label asp-for="Competency.Level5DescFre" class="control-label"><b>Level 5 - French</b></label>
-                    <textarea asp-for="Competency.Level5DescFre" class="form-control" rows="3" cols="45"></textarea>
+                    <textarea asp-for="Competency.Level5DescFre" class="form-control" rows="3" cols="45" required></textarea>
                     <span asp-validation-for="Competency.Level5DescFre" class="text-danger"></span>
                 </div>
             </div>

--- a/Admin/Pages/Competencies/Edit.cshtml.cs
+++ b/Admin/Pages/Competencies/Edit.cshtml.cs
@@ -51,133 +51,93 @@ namespace Admin.Pages.Competencies
                 return NotFound();
             }
 
-            try
-            {
-                Competency.Level1DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level1DescEng = "";
-            }
-            try
-            {
-                Competency.Level1DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 1).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level1DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level2DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level2DescEng = "";
-            }
-            try
-            {
-                Competency.Level2DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 2).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level2DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level3DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level3DescEng = "";
-            }
-            try
-            {
-                Competency.Level3DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 3).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level3DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level4DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level4DescEng = "";
-            }
-            try
-            {
-                Competency.Level4DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 4).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level4DescFre = "";
-            }
-
-
-            try
-            {
-                Competency.Level5DescEng = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescEng;
-            }
-            catch
-            {
-                Competency.Level5DescEng = "";
-            }
-            try
-            {
-                Competency.Level5DescFre = _jobCompetencyService.GetJobCompetencyLevelRequirementDescriptionByIdLevelValue(id, 5).Result.CompetencyLevelReqDescFre;
-            }
-            catch
-            {
-                Competency.Level5DescFre = "";
-            }
-
             return Page();
+        }
+
+        private string CheckUniqueCompetencyName(JobCompetencyDto competency, bool checkEnglish = true)
+        {
+            if (competency == null)
+            {
+                return null;
+            }
+
+            var comp = competency;
+
+            var compTypeName = _context.CompetencyTypes.Where(x => x.Id == comp.TypeId).FirstOrDefault().NameEng.ToLower();
+            if (compTypeName.Contains("ies"))
+            {
+                compTypeName = compTypeName.Replace("ies", "yX");
+            }
+            compTypeName = compTypeName[..^1];
+
+            var competencyIdsOfType = _context.CompetencyTypeGroups.Where(x => x.CompetencyTypeId == comp.TypeId)
+              .Select(x => x.CompetencyId).ToList();
+
+            var activeComps = _context.Competencies.Where(x => x.Id != comp.Id && competencyIdsOfType.Contains(x.Id) && x.Active == 1).ToList();
+            var inactiveComps = _context.Competencies.Where(x => x.Id != comp.Id && competencyIdsOfType.Contains(x.Id) && x.Active == 0).ToList();
+
+            if (checkEnglish)
+            {
+                if (!string.IsNullOrWhiteSpace(comp.NameEng))
+                {
+                    if (activeComps.Select(x => x.NameEng.ToLowerInvariant()).Contains(comp.NameEng.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that English name";
+                    }
+                    else if (inactiveComps.Select(x => x.NameEng.ToLowerInvariant()).Contains(comp.NameEng.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that English name, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+            else
+            {
+                if (!string.IsNullOrWhiteSpace(comp.NameFre))
+                {
+                    if (activeComps.Select(x => x.NameFre.ToLowerInvariant()).Contains(comp.NameFre.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that French name";
+                    }
+                    else if (inactiveComps.Select(x => x.NameFre.ToLowerInvariant()).Contains(comp.NameFre.ToLowerInvariant()))
+                    {
+                        return "There is already a" + (compTypeName[0] == 'e' ? "n " : " ") + compTypeName + " with that French name, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                    }
+                }
+            }
+
+            return null;
         }
 
         // To protect from overposting attacks, enable the specific properties you want to bind to, for
         // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostAsync()
         {
+
+            Competency.TypeNameEng = (await _context.CompetencyTypes.Where(x => x.Id == Competency.TypeId).FirstOrDefaultAsync()).NameEng;
+            Competency.TypeNameFre = (await _context.CompetencyTypes.Where(x => x.Id == Competency.TypeId).FirstOrDefaultAsync()).NameFre;
+
+            var errEng = CheckUniqueCompetencyName(Competency);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("Competency.NameEng", errEng);
+            }
+            var errFre = CheckUniqueCompetencyName(Competency, false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("Competency.NameFre", errFre);
+            }
+
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
-            // _context.Attach(Competency).State = EntityState.Modified;
+            await _jobCompetencyService.UpdateJobCompetency(Competency);
 
-            try
-            {
-                _jobCompetencyService.UpdateJobCompetency(Competency);
-                await _context.SaveChangesAsync();
-            }
-            catch (DbUpdateConcurrencyException)
-            {
-                if (!CompetencyExists(Competency.Id))
-                {
-                    return NotFound();
-                }
-                else
-                {
-                    throw;
-                }
-            }
-
-            Thread.Sleep(5000);
             return RedirectToPage("Details", new { id = Competency.Id });
         }
 
-        private bool CompetencyExists(int id)
-        {
-            return _context.Competencies.Any(e => e.Id == id);
-        }
     }
 }

--- a/Admin/Pages/Competencies/Index.cshtml.cs
+++ b/Admin/Pages/Competencies/Index.cshtml.cs
@@ -17,9 +17,9 @@ namespace Admin.Pages.Competencies
             _logger = logger;
         }
 
-        public void OnGet()
+        public IActionResult OnGet()
         {
-
+            return Redirect("/Competencies/List");
         }
     }
 }

--- a/Admin/Pages/Competencies/List.cshtml
+++ b/Admin/Pages/Competencies/List.cshtml
@@ -61,7 +61,7 @@
 
 @if (itemsThatMatchFilter.Any())
 {
-    <div id="table-container">
+    <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">

--- a/Admin/Pages/Competencies/List.cshtml
+++ b/Admin/Pages/Competencies/List.cshtml
@@ -9,7 +9,7 @@
 @{
     var filterdata = new Dictionary<string, string>
     {
-            { "typeid", typeid },
+            {"typeid", typeid },
             {"filter", Model.Filter }
     };
 
@@ -22,24 +22,24 @@
     }
 
     var itemsThatMatchFilter = Model.Competencies.Where(e => (Model.Filter == null
-        || e.NameEng.ToLower().Contains(@Model.Filter.ToLower())
-        || e.NameFre.ToLower().Contains(@Model.Filter.ToLower()))
+        || e.NameEng.ToLower().Contains(Model.Filter.ToLower())
+        || e.NameFre.ToLower().Contains(Model.Filter.ToLower()))
         && (e.Active == 1));
 
     itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.NameEng.ToLower()).ToList();
 }
 
 <div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
-    <h1>@Model.Type.NameEng / @Model.Type.NameFre</h1>
+    <h1>@Model.Type.NameEng <span class="glyphicon glyphicon-save-file pull-right index-save-file-icon" onclick="print()"></span></h1>
 
-    <p class="space-btns">
+    <p class="space-btns hide-in-print">
         <a class="btn btn-dark" asp-page="/Competencies/Create" asp-route-typeid="@Model.Type.Id">Create New</a>
-        <a href="@("/Competencies/List?typeid=4" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "4" ? classSelectedComp : classUnselectedComp)">Executive</a>
+        <a href="@("/Competencies/List?typeid=4" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right index-right-button @(typeid == "4" ? classSelectedComp : classUnselectedComp)">Executive</a>
         <a href="@("/Competencies/List?typeid=3" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "3" ? classSelectedComp : classUnselectedComp)">Behavioural</a>
         <a href="@("/Competencies/List?typeid=2" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "2" ? classSelectedComp : classUnselectedComp)">Technical</a>
         <a href="@("/Competencies/List?typeid=1" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "1" ? classSelectedComp : classUnselectedComp)">Knowledge</a>
     </p>
-    <form method="post">
+    <form method="post" class="hide-in-print">
         <div class="form-actions no-color">
             <h6>
                 <label for="Filter">Find competencies:</label>
@@ -49,6 +49,11 @@
                 {
                     <span><span class="vertical-bar">|</span> <a href="/Competencies/List?typeid=@typeid">Back to Full List</a></span>
                 }
+
+                <a class="pull-right index-right-button" href="/Competencies/Locate?typeid=@typeid"
+                title="Find out which jobs require the specified competency" data-toggle="tooltip">
+                    Locate Competencies
+                </a>
             </h6>
         </div>
     </form>
@@ -66,7 +71,7 @@
                     <th class="col-4"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Description French</b></th>
                     <th class="col-1">
                         <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
-                        class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
+                        class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
                         aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
                         alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                         title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
@@ -89,10 +94,13 @@
                         <td>
                             @Html.DisplayFor(modelItem => item.DescFre)
                         </td>
-                        <td class="text-center">
+                        <td class="text-center hide-in-print">
                             <a asp-page="./Details" asp-route-id="@item.Id">Details</a>
                             <a asp-page="./Edit" asp-route-id="@item.Id">Edit</a>
                             <a asp-page="./Delete" asp-route-id="@item.Id">Delete</a>
+                        </td>
+                        <td class="hide-when-not-in-print table-cell text-center">
+                            <a asp-page="./Details" asp-route-id="@item.Id" class="print-link underline">Details</a>
                         </td>
                     </tr>
                 }

--- a/Admin/Pages/Competencies/List.cshtml.cs
+++ b/Admin/Pages/Competencies/List.cshtml.cs
@@ -29,6 +29,8 @@ namespace Admin.Pages.Competencies
 
         public bool DisplayTopOfPage { get; set; }
 
+        public double LastTableContainerHeight { get; set; } = 300;
+
         private async Task PreparePage(int typeId)
         {
             var accepetedTypeIds = _context.CompetencyTypes.Select(c => c.Id).ToList();
@@ -51,6 +53,17 @@ namespace Admin.Pages.Competencies
                 if (sessionStr.ToLower() == "false")
                 {
                     DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
                 }
             }
         }

--- a/Admin/Pages/Positions/Create.cshtml
+++ b/Admin/Pages/Positions/Create.cshtml
@@ -14,20 +14,16 @@
 <div class="space-tables-vertically">
     <div class="row">
         <div class="col-md-12">
-            <form method="post">
+            <form method="post" class="trimFormWhenSubmitting">
                 
                 @{
-                    var editModel = new EditModel(Model.GetContext(), Model.GetJobCompetencyService(), Model.GetJobCertificateService());
+                    var editModel = new EditModel(Model.GetContext(), Model.GetJobCompetencyService(), Model.GetJobCertificateService(), Model.GetJobPositionService());
                     editModel.JobPosition = Model.JobPosition;
                     editModel.AddedCertificates = Model.AddedCertificates;
                     editModel.JobCompetenciesKnowledge = Model.JobCompetenciesKnowledge;
                     editModel.JobCompetenciesTechnical = Model.JobCompetenciesTechnical;
                     editModel.JobCompetenciesBehavioural = Model.JobCompetenciesBehavioural;
                     editModel.JobCompetenciesExecutive = Model.JobCompetenciesExecutive;
-                    editModel.TitleEng = Model.TitleEng;
-                    editModel.TitleFre = Model.TitleFre;
-                    editModel.DescriptionEng = Model.DescriptionEng;
-                    editModel.DescriptionFre = Model.DescriptionFre;
                     editModel.PositionCompetencyRatings = Model.PositionCompetencyRatings;
                     editModel.AddedKnowledgeCompetencies = Model.AddedKnowledgeCompetencies;
                     editModel.AddedTechnicalCompetencies = Model.AddedTechnicalCompetencies;

--- a/Admin/Pages/Positions/Create.cshtml.cs
+++ b/Admin/Pages/Positions/Create.cshtml.cs
@@ -22,12 +22,14 @@ namespace Admin.Pages.Positions
 
         private readonly JobCompetencyService _jobCompetencyService;
         private readonly JobCertificateService _jobCertificateService;
+        private readonly JobPositionService _jobPositionService;
 
-        public CreateModel(DataModel.CctDbContext context, JobCompetencyService jobCompetencyService, JobCertificateService jobCertificateService)
+        public CreateModel(DataModel.CctDbContext context, JobCompetencyService jobCompetencyService, JobCertificateService jobCertificateService, JobPositionService jobPositionService)
         {
             _context = context;
             _jobCompetencyService = jobCompetencyService;
             _jobCertificateService = jobCertificateService;
+            _jobPositionService = jobPositionService;
         }
 
         [BindProperty]
@@ -49,14 +51,7 @@ namespace Admin.Pages.Positions
         public int Id { get; set; }
         [BindProperty(SupportsGet = true)]
         public int JobGroupId { get; set; } = 2;
-        [BindProperty(SupportsGet = true)]
-        public string TitleEng { get; set; } = string.Empty;
-        [BindProperty(SupportsGet = true)]
-        public string TitleFre { get; set; } = string.Empty;
-        [BindProperty(SupportsGet = true)]
-        public string DescriptionEng { get; set; } = string.Empty;
-        [BindProperty(SupportsGet = true)]
-        public string DescriptionFre { get; set; } = string.Empty;
+
         [BindProperty(SupportsGet = true)]
         public string AddedCertificateIds { get; set; } = string.Empty;
         [BindProperty(SupportsGet = true)]
@@ -73,14 +68,12 @@ namespace Admin.Pages.Positions
         public JobGroupDto[] JobGroups { get; set; }
 
         [BindProperty]
-        public JobPositionDto CurrentJobPosition { get; set; } // used for the "save a copy" feature
-
+        public JobPositionDto CurrentJobPosition { get; set; } // used by the "save a copy" feature
         public JobGroupDto CurrentSelectedJobGroup { get; set; }
         public JobCertificateDto[] JobCertificates { get; set; }
         [BindProperty(SupportsGet = true)]
         public string JobHLCategory { get; set; }
         [BindProperty]
-        [CheckOneRegionSelected]
         public List<string> SelectedRegionIds { get; set; } = new List<string> { };
         [BindProperty(SupportsGet = true)]
         public int JobGroupLevelId { get; set; }
@@ -91,7 +84,7 @@ namespace Admin.Pages.Positions
         [BindProperty(SupportsGet = true)]
         public string LevelValue { get; set; }
 
-        // Normally, the three private properties shouldn't be accessible, but it was necessary in order to use the partial view
+        // Normally, the four private properties shouldn't be accessible, but it was necessary in order to use the partial view
 
         public CctDbContext GetContext()
         {
@@ -106,6 +99,264 @@ namespace Admin.Pages.Positions
         public JobCertificateService GetJobCertificateService()
         {
             return _jobCertificateService;
+        }
+
+        public JobPositionService GetJobPositionService()
+        {
+            return _jobPositionService;
+        }
+
+        private async Task ValidateModel()
+        {
+            var errEng = await CheckUniquePositionName(JobPosition);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("JobPosition.TitleEng", errEng);
+            }
+            var errFre = await CheckUniquePositionName(JobPosition, false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("JobPosition.TitleFre", errFre);
+            }
+
+            bool oneRegionSelected = !string.IsNullOrWhiteSpace(RegionIds);
+
+            bool atLeastOneComp = (
+                (!string.IsNullOrWhiteSpace(AddedKnowledgeCompetencyIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedTechnicalCompetencyIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedBehaviouralCompetencyIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedExecutiveCompetencyIds))
+                );
+
+            if (!atLeastOneComp)
+            {
+                ModelState.AddModelError("AddedBehaviouralCompetencyIds", "Make sure that at least one competency has been added");
+            }
+
+            if (!oneRegionSelected)
+            {
+                ModelState.AddModelError("SelectedRegionIds", "Make sure that at least one region is selected");
+            }
+        }
+
+        public async Task<List<JobPositionDto>> GetAllJobs()
+        {
+            return (await _jobPositionService.GetAllJobPositions()).ToList();
+        }
+
+        private async Task<string> CheckUniquePositionName(JobPosition position, bool checkEnglish = true)
+        {
+            if (position == null)
+            {
+                return null;
+            }
+
+            var pos = position;
+
+            var positionsOfLevel = (await GetAllJobs()).Where(x => x.LevelCode.ToLower() == LevelCode.ToLower()).ToList();
+
+            if (positionsOfLevel.Any())
+            {
+                var activeJobs = positionsOfLevel.Where(x => x.Active == 1 && x.JobTitleId != pos.Id).ToList();
+                var inactiveJobs = positionsOfLevel.Where(x => x.Active == 0 && x.JobTitleId != pos.Id).ToList();
+
+                if (checkEnglish)
+                {
+                    if (!string.IsNullOrWhiteSpace(pos.TitleEng))
+                    {
+                        if (activeJobs.Select(x => x.JobTitleEng.ToLowerInvariant()).Contains(pos.TitleEng.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that English title";
+                        }
+                        else if (inactiveJobs.Select(x => x.JobTitleEng.ToLowerInvariant()).Contains(pos.TitleEng.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that English title, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                        }
+                    }
+                }
+                else
+                {
+                    if (!string.IsNullOrWhiteSpace(pos.TitleFre))
+                    {
+                        if (activeJobs.Select(x => x.JobTitleFre.ToLowerInvariant()).Contains(pos.TitleFre.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that French title";
+                        }
+                        else if (inactiveJobs.Select(x => x.JobTitleFre.ToLowerInvariant()).Contains(pos.TitleFre.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that French title, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
+
+        private async Task PreparePageModel(int compIdToIgnore = 0, int certIdToIgnore = 0)
+        {
+            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
+            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
+            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
+            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
+
+            JobCertificates = await _jobCompetencyService.GetJobCertificates();
+            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
+
+            JobGroups = await _jobCompetencyService.GetJobGroups();
+
+            if (!_context.JobGroups.Select(x => x.Id).Contains(JobGroupId))
+            {
+                JobGroupId = JobGroups[0].Id;
+            }
+
+            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
+            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
+            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
+            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
+            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
+
+            var acceptedRegionsIds = await _context.JobLocationRegions.Where(x => x.Active == 1).Select(x => x.Id).ToListAsync();
+            RegionIds = string.Empty;
+            foreach (var id in SelectedRegionIds.Distinct().ToList())
+            {
+                int regionInt = 0;
+                try
+                {
+                    regionInt = int.Parse(id);
+                }
+                catch
+                {
+                    regionInt = 0;
+                }
+
+                if (acceptedRegionsIds.Contains(regionInt))
+                {
+                    RegionIds += id + "-";
+                } 
+            }
+
+            string[] compIdsArray = { AddedKnowledgeCompetencyIds, AddedTechnicalCompetencyIds, 
+                AddedBehaviouralCompetencyIds, AddedExecutiveCompetencyIds};
+            List<JobCompetencyRatingDto>[] compsArray = { AddedKnowledgeCompetencies, AddedTechnicalCompetencies,
+                AddedBehaviouralCompetencies, AddedExecutiveCompetencies };
+
+            for (int i = 0; i < compIdsArray.Length; i++)
+            {
+                var ids = compIdsArray[i];
+                var compType = compsArray[i];
+
+                foreach (var cid in ids.Split("-").Distinct())
+                {
+                    if (!string.IsNullOrEmpty(cid))
+                    {
+                        if (cid.Contains("&"))
+                        {
+                            var cidc = cid.Split("&")[0];
+                            var clevel = cid.Split("&")[1];
+
+                            if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
+                            {
+                                try
+                                {
+                                    var cidInt = int.Parse(cidc);
+                                    if (cidInt != compIdToIgnore)
+                                    {
+                                        var cLevel = int.Parse(clevel);
+                                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
+                                        if (competency != null)
+                                        {
+                                            if (competency.Active == 1)
+                                            {
+                                                compType.Add(competency);
+                                            }
+                                        }
+                                    }
+                                }
+                                catch 
+                                {
+                                    compIdToIgnore = -10;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (compIdToIgnore != 0)
+            {
+                AddedKnowledgeCompetencyIds = string.Empty;
+                AddedTechnicalCompetencyIds = string.Empty;
+                AddedBehaviouralCompetencyIds = string.Empty;
+                AddedExecutiveCompetencyIds = string.Empty;
+                foreach (var competency in AddedKnowledgeCompetencies)
+                {
+                    AddedKnowledgeCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
+                }
+                foreach (var competency in AddedTechnicalCompetencies)
+                {
+                    AddedTechnicalCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
+                }
+                foreach (var competency in AddedBehaviouralCompetencies)
+                {
+                    AddedBehaviouralCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
+                }
+                foreach (var competency in AddedExecutiveCompetencies)
+                {
+                    AddedExecutiveCompetencyIds += competency.CompetencyId + "&" + (competency.RatingValue + 5) + "-";
+                }
+            }
+
+            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
+            {
+                if (!string.IsNullOrEmpty(cid))
+                {
+                    if (cid.Contains("&"))
+                    {
+                        try
+                        {
+                            var cidInt = int.Parse(cid.Split("&")[0]);
+                            if (cidInt != certIdToIgnore)
+                            {
+                                var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
+                                if (certificateDto != null)
+                                {
+                                    if (certificateDto.Active == 1)
+                                    {
+                                        var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
+                                        if (certificateDescDto != null)
+                                        {
+                                            certificateDto.CertificateDescId = certificateDescDto.Id;
+                                            if (certificateDescDto.Active == 1)
+                                            {
+                                                certificateDto.DescEng = certificateDescDto.DescEng;
+                                                certificateDto.DescFre = certificateDescDto.DescFre;
+                                            }
+                                            AddedCertificates.Add(certificateDto);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        catch 
+                        {
+                            certIdToIgnore = -10;
+                        }
+                    }
+                }
+            }
+            if (certIdToIgnore != 0)
+            {
+                AddedCertificateIds = string.Empty;
+                foreach (var certificate in AddedCertificates)
+                {
+                    AddedCertificateIds += certificate.Id + "&" + certificate.CertificateDescId + "-";
+                }
+            }
+
+            await ValidateModel();
         }
 
         public async Task<IActionResult> OnGetAsync(int? id)
@@ -128,8 +379,8 @@ namespace Admin.Pages.Positions
             if (savePositonsAs)
             {
                 Id = 0;
-                DescriptionEng = JobPosition.PositionDescEng;
-                DescriptionFre = JobPosition.PositionDescFre;
+                JobPosition.TitleEng = "";
+                JobPosition.TitleFre = "";
 
                 CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(id.Value);
                 var PositionCertificates = await _jobCompetencyService.GetJobCertificatesById(id.Value);
@@ -161,56 +412,42 @@ namespace Admin.Pages.Positions
                         }
                     }
                 }
-                var competenciesType1 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 1);
-                if (competenciesType1 != null)
-                {
-                    foreach (var competency in competenciesType1)
-                    {
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencyIds += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
 
-                var competenciesType2 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 2);
-                if (competenciesType2 != null)
+                string[] compIdsArray = new string[4];
+                List<JobCompetencyRatingDto>[] compsArray = { AddedKnowledgeCompetencies, AddedTechnicalCompetencies,
+                    AddedBehaviouralCompetencies, AddedExecutiveCompetencies};
+
+                for (int i = 0; i < compIdsArray.Length; i++)
                 {
-                    foreach (var competency in competenciesType2)
+                    bool exec = (i == compsArray.Length - 1);
+
+                    var compType = compsArray[i];
+
+                    var competenciesOfType = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, i + 1);
+                    if (competenciesOfType != null)
                     {
-                        if (competency != null)
+                        foreach (var competency in competenciesOfType)
                         {
-                            AddedTechnicalCompetencyIds += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
-                            AddedTechnicalCompetencies.Add(competency);
+                            if (competency != null)
+                            {
+                                if (!exec)
+                                {
+                                    compIdsArray[i] += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
+                                }
+                                else
+                                {
+                                    compIdsArray[i] += competency.CompetencyId + "&" + (competency.CompetencyRatingLevelId +
+                                        (competency.CompetencyRatingLevelId <= 5 ? 5 : 0)) + "-";
+                                }
+                                compType.Add(competency);
+                            }
                         }
                     }
                 }
-                var competenciesType3 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 3);
-                if (competenciesType3 != null)
-                {
-                    foreach (var competency in competenciesType3)
-                    {
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencyIds += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-                var competenciesType4 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 4);
-                if (competenciesType4 != null)
-                {
-                    foreach (var competency in competenciesType4)
-                    {
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencyIds += competency.CompetencyId + "&" + (competency.CompetencyRatingLevelId +
-                                (competency.CompetencyRatingLevelId <= 5 ? 5 : 0)) + "-";
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
+                AddedKnowledgeCompetencyIds = compIdsArray[0];
+                AddedTechnicalCompetencyIds = compIdsArray[1];
+                AddedBehaviouralCompetencyIds = compIdsArray[2];
+                AddedExecutiveCompetencyIds = compIdsArray[3];
 
                 JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
                 JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
@@ -240,760 +477,180 @@ namespace Admin.Pages.Positions
                 SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
                 JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
                 LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
+
+               // Since every position has all behavioural elements, they get added here by default to save time
+
+                var behavComps = (await _jobCompetencyService.GetJobCompetenciesByTypeId(3)).Where(x => x.Active == 1).ToList();
+                var levelOneRating = await _context.CompetencyRatingLevels.Where(x => x.Value == 1).FirstOrDefaultAsync();
+
+                string behavIds = "";
+
+                foreach (var comp in behavComps)
+                {
+                    var compRatingGroup = await _context.CompetencyRatingGroups
+                        .Where(x => x.CompetencyId == comp.Id && x.CompetencyRatingLevelId == 1).FirstOrDefaultAsync();
+
+                    var compWithDescs = await _jobCompetencyService.GetJobCompetencyById(comp.Id);
+
+                    var newComp = new JobCompetencyRatingDto
+                    {
+                        JobPositionId = 0,
+                        TypeId = 3,
+                        TypeNameEng = comp.TypeNameEng,
+                        TypeNameFre = comp.TypeNameFre,
+                        CompetencyId = comp.Id,
+                        CompetencyNameEng = comp.NameEng,
+                        CompetencyNameFre = comp.NameFre,
+                        CompetencyDescEng = comp.DescEng,
+                        CompetencyDescFre = comp.DescFre,
+                        RatingValue = levelOneRating.Value,
+                        RatingNameEng = levelOneRating.NameEng,
+                        RatingNameFre = levelOneRating.NameFre,
+                        RatingDescEng = levelOneRating.DescEng,
+                        RatingDescFre = levelOneRating.DescFre,
+                        CompetencyRatingLevelId = 1,
+                        CompetencyLevelReqDescEng = compWithDescs.Level1DescEng,
+                        CompetencyLevelReqDescFre = compWithDescs.Level1DescFre,
+                        Active = 1,
+                        CompetencyLevelRequirementId = compRatingGroup.CompetencyLevelRequirementId
+                    };
+                    AddedBehaviouralCompetencies.Add(newComp);
+                    behavIds += newComp.CompetencyId + "&" + newComp.CompetencyRatingLevelId + "-";
+                }
+                AddedBehaviouralCompetencyIds = behavIds;
             }
 
             return Page();
         }
+
         public async Task OnPostGroup()
         {
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    if (certificateDto != null)
-                    {
-                        certificateDto.CertificateDescId = int.Parse(cid.Split("&")[1]);
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
-
+            await PreparePageModel();
         }
+
         public async Task OnPostCertificate()
         {
-
             var certificate = Request.Form["certificate"];
             var certificatedescId = Request.Form["CertificateDescriptionId"];
-            AddedCertificateIds += certificate[0] + "&" + certificatedescId[0] + "-";
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
+            if (certificate != Microsoft.Extensions.Primitives.StringValues.Empty 
+                && certificatedescId != Microsoft.Extensions.Primitives.StringValues.Empty)
             {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
+                AddedCertificateIds += certificate[0] + "&" + certificatedescId[0] + "-";
+            }
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    if (certificateDto != null)
-                    {
-                        certificateDto.CertificateDescId = int.Parse(cid.Split("&")[1]);
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
+            await PreparePageModel();
         }
+
         public async Task OnPostCompetency(string competencytypename)
         {         
             var Id = Request.Form[$"{competencytypename}Competency"];
             var level = Request.Form[$"{competencytypename}Level"];
-            TitleEng = Request.Form["titleEng"];
-            TitleFre = Request.Form["titleFre"];
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            if (competencytypename == "knowledge")
-            {
-                AddedKnowledgeCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            else if (competencytypename == "technical")
-            {
-                AddedTechnicalCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            else if (competencytypename == "behavioural")
-            {
-                AddedBehaviouralCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            else if (competencytypename == "executive")
-            {
-                AddedExecutiveCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
+            if (Id != Microsoft.Extensions.Primitives.StringValues.Empty
+                && level != Microsoft.Extensions.Primitives.StringValues.Empty)
             {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
+                var strToAdd = Id[0] + "&" + level[0] + "-";
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
+                if (competencytypename == "knowledge")
+                {
+                    AddedKnowledgeCompetencyIds += strToAdd;
+                }
+                else if (competencytypename == "technical")
+                {
+                    AddedTechnicalCompetencyIds += strToAdd;
+                }
+                else if (competencytypename == "behavioural")
+                {
+                    AddedBehaviouralCompetencyIds += strToAdd;
+                }
+                else if (competencytypename == "executive")
+                {
+                    AddedExecutiveCompetencyIds += strToAdd;
                 }
             }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    if (certificateDto != null)
-                    {
-                        certificateDto.CertificateDescId = int.Parse(cid.Split("&")[1]);
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
+            await PreparePageModel();
         }
 
         public async Task OnPostDeleteCertificate(int certificateid)
         {
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            TitleEng = Request.Form["titleEng"];
-            TitleFre = Request.Form["titleFre"];            
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedCertificateIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    if (cidInt != certificateid)
-                    {
-                        var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                        var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
-                        certificateDto.CertificateDescId = certificateDescDto.Id;
-                        if (certificateDescDto.Active == 1)
-                        {
-                            certificateDto.DescEng = certificateDescDto.DescEng;
-                            certificateDto.DescFre = certificateDescDto.DescFre;
-                        }
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
-            AddedCertificateIds = string.Empty;
-            foreach (var certificate in AddedCertificates)
-            {
-                AddedCertificateIds += certificate.Id + "&" + certificate.CertificateDescId + "-";
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-
+            await PreparePageModel(0, certificateid);
         }
+
         public async Task OnPostDelete(int competencyid)
         {
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            TitleEng = Request.Form["titleEng"];
-            TitleFre = Request.Form["titleFre"];
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    if (certificateDto != null)
-                    {
-                        certificateDto.CertificateDescId = int.Parse(cid.Split("&")[1]);
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedKnowledgeCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedBehaviouralCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedTechnicalCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedExecutiveCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            AddedKnowledgeCompetencyIds = string.Empty;
-            AddedTechnicalCompetencyIds = string.Empty;
-            AddedBehaviouralCompetencyIds = string.Empty;
-            AddedExecutiveCompetencyIds = string.Empty;
-            foreach (var competency in AddedKnowledgeCompetencies)
-            {
-                AddedKnowledgeCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
-            }
-            foreach (var competency in AddedTechnicalCompetencies)
-            {
-                AddedTechnicalCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
-            }
-            foreach (var competency in AddedBehaviouralCompetencies)
-            {
-                AddedBehaviouralCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
-            }
-            foreach (var competency in AddedExecutiveCompetencies)
-            {
-                AddedExecutiveCompetencyIds += competency.CompetencyId + "&" + (competency.RatingValue + 5) + "-";
-            }
+            await PreparePageModel(competencyid);
         }
+
         public async Task<IActionResult> OnPostCreateAsync()
         {
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            var acceptedRegionIds = _context.JobLocationRegions.Select(x => x.Id).ToList();
-            foreach (var id in SelectedRegionIds.Distinct())
-            {
-                if (int.TryParse(id, out int intId))
-                {
-                    if (acceptedRegionIds.Contains(intId))
-                    {
-                        RegionIds += id + "-";
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    if (certificateDto != null)
-                    {
-                        certificateDto.CertificateDescId = int.Parse(cid.Split("&")[1]);
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
+            await PreparePageModel();
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-
-            bool validModel = false;
-
-            if (ModelState.IsValid || ModelState.ErrorCount == 1)   // the ModelState seems to always have at least one error, but it's something
-                                                                    // that should not matter
-            {
-                validModel = true;
-            }
-
-            if (!validModel)    // the model can't be validated right at the beginning of this function, otherwise the DTO
-                                // won't be in the proper state, since its properties won't have been set, yet
+            if (!ModelState.IsValid)    // the model can't be validated right at the beginning of this function, otherwise the DTO
+                                        // won't be in the proper state, since its properties won't have been set, yet
             {
                 return Page();
             }
 
-            var parameters = string.Format($"&titleEng={TitleEng}&titleFre={TitleFre}&descriptionEng={DescriptionEng}&descriptionFre={DescriptionFre}");
-            var jobPositionId = await _jobCompetencyService.PostJobPositionGetId(parameters);
+            int jobPositionId = await _jobCompetencyService.PostJobPositionGetId(JobPosition);
+
+            bool validLevelValue = true;
+
+            if (string.IsNullOrWhiteSpace(LevelValue))
+            {
+                validLevelValue = false;
+            }
+            else
+            {
+                if (!LevelValue.Contains("/"))
+                {
+                    validLevelValue = false;
+                }
+                else
+                {
+                    var splitLevel = LevelValue.Split("/");
+
+                    try
+                    {
+                        int subGroupId = int.Parse(splitLevel[0]);
+                        int jobGroupLevelId = int.Parse(splitLevel[1]);
+                        string code = splitLevel[2];
+
+                        var levelValues = JobGroupPositions.Select(x => x.LevelValue).ToList();
+                        List<int> levelValuesInt = new List<int>();
+
+                        foreach (var value in levelValues)
+                        {
+                            levelValuesInt.Add(int.Parse(value));
+                        }
+
+                        if (!_context.SubJobGroups.Select(x => x.Id).ToList().Contains(subGroupId) ||
+                            !levelValuesInt.Contains(jobGroupLevelId))
+                        {
+                            validLevelValue = false;
+                        }
+                        else
+                        {
+                            var codes = JobGroupPositions.Select(x => x.LevelCode.ToLower()).ToList();
+                            if (!codes.Contains(code.ToLower()))
+                            {
+                                validLevelValue = false;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        validLevelValue = false;
+                    }
+                }
+            }
+
+            if (!validLevelValue)
+            {
+                JobGroupId = JobGroups[0].Id;
+                LevelValue = "25/1/AS-01";
+            }
 
             var jobGroupPosition = new JobGroupPosition()
             {
@@ -1002,70 +659,35 @@ namespace Admin.Pages.Positions
                 SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
                 JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
             };
-             _jobCompetencyService.PostJobGroupPosition(jobGroupPosition);
-            foreach(var competency in AddedKnowledgeCompetencies)
+            await _jobCompetencyService.PostJobGroupPosition(jobGroupPosition);
+
+            List<JobCompetencyRatingDto>[] compList = { AddedKnowledgeCompetencies, AddedTechnicalCompetencies,
+            AddedBehaviouralCompetencies, AddedExecutiveCompetencies };
+            for (int i = 0; i < compList.Length; i++)
             {
-                var jobrolepositioncompetency = new JobRolePositionCompetencyRating() { 
-                    JobPositionId = jobPositionId,              
-                    CompetencyId = competency.CompetencyId,
-                    CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                    CompetencyTypeId = 1,
-                    CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                    SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                    JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                    JobGroupId = JobGroupId
-                };
-               _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
+                var currCompType = compList.ElementAt(i);
+
+                foreach (var competency in currCompType)
+                {
+                    var ratingLevelId = competency.CompetencyRatingLevelId - (competency.CompetencyRatingLevelId > 5 ? 5 : 0);
+                    var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
+                    {
+                        JobPositionId = jobPositionId,
+                        CompetencyId = competency.CompetencyId,
+                        CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
+                        CompetencyTypeId = i + 1,
+                        CompetencyRatingLevelId = ratingLevelId,
+                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
+                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
+                        JobGroupId = JobGroupId
+                    };
+                    await _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
+                }
             }
-                foreach (var competency in AddedTechnicalCompetencies)
-                {
-                    var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
-                    {
-                        JobPositionId = jobPositionId,
-                        CompetencyId = competency.CompetencyId,
-                        CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                        CompetencyTypeId = 2,
-                        CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                        JobGroupId = JobGroupId
-                    };
 
-                    _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-                }
-                foreach (var competency in AddedBehaviouralCompetencies)
-                {
-                    var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
-                    {
-                        JobPositionId = jobPositionId,
-                        CompetencyId = competency.CompetencyId,
-                        CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                        CompetencyTypeId = 3,
-                        CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                        JobGroupId = JobGroupId
-                    };
-
-                    _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-                }
-                foreach (var competency in AddedExecutiveCompetencies)
-                {
-                    var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
-                    {
-                        JobPositionId = jobPositionId,
-                        CompetencyId = competency.CompetencyId,
-                        CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                        CompetencyTypeId = 4,
-                        CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                        JobGroupId = JobGroupId
-                    };
-
-                    _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-                }
-                foreach(var id in SelectedRegionIds)
+            foreach (var id in RegionIds.Split("-"))
+            {
+                if (!string.IsNullOrWhiteSpace(id))
                 {
                     var jobrolepositionlocation = new JobRolePositionLocation()
                     {
@@ -1073,43 +695,44 @@ namespace Admin.Pages.Positions
                         JobGroupId = JobGroupId,
                         JobPositionId = jobPositionId,
                         SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1])                      
+                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1])
                     };
-                    _jobCompetencyService.PostJobRolePositionLocation(jobrolepositionlocation);
+                    await _jobCompetencyService.PostJobRolePositionLocation(jobrolepositionlocation);
                 }
+            }
 
-                var acceptedHLCategoryIds = _context.JobHLCategories.Select(x => x.Id).ToList();
-                if (int.TryParse(JobHLCategory, out int jobHLId))
+            var acceptedHLCategoryIds = _context.JobHLCategories.Select(x => x.Id).ToList();
+            if (int.TryParse(JobHLCategory, out int jobHLId))
+            {
+                if (!acceptedHLCategoryIds.Contains(jobHLId))
                 {
-                    if (!acceptedHLCategoryIds.Contains(jobHLId))
-                    {
-                        JobHLCategory = "1";
-                    }
+                    JobHLCategory = "1";
                 }
-                var jobrolepositionhlcategory = new JobRolePositionHLCategory()
+            }
+            var jobrolepositionhlcategory = new JobRolePositionHLCategory()
+            {
+                JobGroupId = JobGroupId,
+                JobPositionId = jobPositionId,
+                SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
+                JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
+                JobHLCategoryId = int.Parse(JobHLCategory)
+            };
+            await _jobCompetencyService.PostJobRolePositionHLCategory(jobrolepositionhlcategory);
+
+            foreach(var certificate in AddedCertificates)
+            {
+                var jobrolepositioncertificate = new JobRolePositionCertificate()
                 {
-                    JobGroupId = JobGroupId,
                     JobPositionId = jobPositionId,
+                    JobGroupId = JobGroupId,
                     SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
                     JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                    JobHLCategoryId = int.Parse(JobHLCategory)
+                    CertificateDescriptionId = certificate.CertificateDescId,
+                    CertificateId = certificate.Id,
                 };
-                _jobCompetencyService.PostJobRolePositionHLCategory(jobrolepositionhlcategory);
-                foreach(var certificate in AddedCertificates)
-                {
-                    var jobrolepositioncertificate = new JobRolePositionCertificate()
-                    {
-                        JobPositionId = jobPositionId,
-                        JobGroupId = JobGroupId,
-                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                        CertificateDescriptionId = certificate.CertificateDescId,
-                        CertificateId = certificate.Id,
-                    };
-                    _jobCompetencyService.PostJobRolePositionCertificate(jobrolepositioncertificate);
+                await _jobCompetencyService.PostJobRolePositionCertificate(jobrolepositioncertificate);
+            }
 
-                }
-            Thread.Sleep(10000);
             return RedirectToPage("Details", new { positionid = jobPositionId });
         }
 

--- a/Admin/Pages/Positions/Delete.cshtml.cs
+++ b/Admin/Pages/Positions/Delete.cshtml.cs
@@ -30,7 +30,7 @@ namespace Admin.Pages.Positions
         public JobPosition JobPosition { get; set; }
         public string ErrorMessage { get; set; }
 
-        public async Task<IActionResult> OnGetAsync(int? id, bool? saveChangesError = false)
+        public async Task<IActionResult> OnGetAsync(int? id)
         {
             if (id == null)
             {
@@ -49,10 +49,7 @@ namespace Admin.Pages.Positions
             {
                 return NotFound();
             }
-            if (saveChangesError.GetValueOrDefault())
-            {
-                ErrorMessage = String.Format("Delete {ID} failed. Try again", id);
-            }
+ 
             return Page();
         }
 
@@ -63,18 +60,20 @@ namespace Admin.Pages.Positions
                 return NotFound();
             }
 
-            try
+            JobPosition = await _context.JobPositions.FindAsync(id);
+
+            if (JobPosition == null)
             {
-                _jobPositionService.DeleteJobPosition(JobPosition);
-                Thread.Sleep(5000);
-                return RedirectToPage("./Index");
+                return NotFound();
             }
-            catch (DbUpdateException ex)
+            if (JobPosition.Active != 1)
             {
-                _logger.LogError(ex, ErrorMessage);
-                return RedirectToAction("./Delete",
-                                     new { id, saveChangesError = true });
+                return NotFound();
             }
+
+            await _jobPositionService.DeleteJobPosition(JobPosition);
+
+            return RedirectToPage("./Index");
         }
     }
 }

--- a/Admin/Pages/Positions/Details.cshtml
+++ b/Admin/Pages/Positions/Details.cshtml
@@ -1,5 +1,6 @@
 ﻿@page
 @model Admin.Pages.Positions.DetailsModel
+@inject Admin.Data.FormattingService Formatter
 
 @{
     ViewData["Title"] = "Details";
@@ -102,7 +103,7 @@
             {
                 <tr>
                     <th colspan="2" class="table-header-row">
-                        <span class="expand-elements-in-next-rows closed" data-toggle="tooltip" title="Toggle expandable elements">
+                        <span class="expand-elements-in-next-rows closed" data-toggle="tooltip" title="Toggle expandable elements" id="certificatesRow">
                             CERTIFICATIONS / ATTESTATIONS
                         </span>
                     </th>
@@ -116,11 +117,81 @@
                     <tr>
                         <td colspan="2">
                             <div class="accordion" id="@divKey">
-                                <button class="btn btn-link collapsed text-wrap text-left no-padding" type="button" data-toggle="collapse" data-target="#@key" aria-expanded="false" aria-controls="collapseOne">
-                                    @certificate.NameEng / @certificate.NameFre
+                                <button class="btn btn-link collapsed text-wrap text-left no-padding" type="button" data-toggle="collapse" data-target="#@key" aria-expanded="false" aria-controls="collapseOne" id="certificateScroll-@certificate.Id">
+                                    @certificate.NameEng <b>/</b> @certificate.NameFre
                                 </button>
                                 <div id="@key" class="collapse" aria-labelledby="headingFour" data-parent="#@divKey">
                                     <div class="card-body">
+
+                                        @{
+                                            bool emptyCertificateDesc = certificate.CertificateDescEng == "" || certificate.CertificateDescFre == "";
+                                        }
+
+                                        @if (!emptyCertificateDesc)
+                                        {
+                                            <button type="button" class="btn btn-link collapsed no-padding small-margin-bottom display-block" data-toggle="collapse" data-target="#CertificateDescription-@certificate.Id">
+                                                Certificate Descritpion
+                                            </button>
+
+                                            <div id="CertificateDescription-@certificate.Id" class="collapse">
+                                                <div class="card-body no-padding-top xs-margin-bottom">
+                                                    @{
+                                                        string[] languages = { "English", "French" };
+                                                        string[] descriptions = { certificate.CertificateDescEng, certificate.CertificateDescFre };
+
+                                                        for (int i = 0; i < descriptions.Length; i++)
+                                                        {
+                                                            <p class="bold @(i > 0 ? "small-margin-top" : "")">
+                                                                @languages[i]
+                                                            </p>
+
+                                                            <div>
+                                                            @{
+                                                                var descPortions = descriptions[i].Split("\r\n");
+                                                                bool oneLinkAdded = false;
+                                                                foreach (var desc in descPortions)
+                                                                {
+                                                                    bool containsALink = false;
+                                                                    if (desc.Contains("http"))
+                                                                    {
+                                                                        containsALink = true;
+                                                                    }
+                                                                    if (!containsALink)
+                                                                    {
+                                                                        <span>@desc</span>
+                                                                        <br />
+                                                                    }
+                                                                    else
+                                                                    {
+                                                                        var formattedLink = Formatter.FormatCertificateDescriptionLink(desc);
+                                                                        var href = formattedLink[0];
+                                                                        var displayStr = formattedLink[1];
+                                                                            
+                                                                        if (oneLinkAdded)
+                                                                        {
+                                                                            <span class="inline-block margin-left-link-spacing">| </span>
+                                                                        }
+
+                                                                        <a href="@href" target="_blank">
+                                                                            @displayStr
+                                                                            <img src="~/images/icons/external_link_icon.png" 
+                                                                            class="external-link" alt="Open link in new tab" />
+                                                                        </a>
+
+                                                                        if (!oneLinkAdded)
+                                                                        {
+                                                                            oneLinkAdded = true;
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                            </div>
+                                                        }
+                                                    }
+                                                </div>
+                                            </div>
+                                        }
+
                                         @if (string.IsNullOrWhiteSpace(certificate.DescEng) && string.IsNullOrWhiteSpace(certificate.DescFre))
                                         {
                                             <p class="no-margins">
@@ -135,11 +206,11 @@
                                         else
                                         {
                                             <p>
-                                                <b>English Description</b><br />
+                                                <b>Selected English Description</b><br />
                                                 <span class="small-padding-top display-block">@(string.IsNullOrWhiteSpace(certificate.DescEng) ? "No description specified in English" : certificate.DescEng)</span>
                                             </p>
                                             <p>
-                                                <b>French Description</b><br />
+                                                <b>Selected French Description</b><br />
                                                 <span class="small-padding-top display-block">@(string.IsNullOrWhiteSpace(certificate.DescFre) ? "Aucune description specifée en français" : certificate.DescFre)</span>
                                             </p>
                                             <div class="expanded-item-navigation">
@@ -147,7 +218,7 @@
                                                     Edit Certificate <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                                 </a> <span class="small-padding-left">|</span>
                                                 <a href="/Certificates/Descriptions/Edit?id=@certificate.CertificateDescId" target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
-                                                    Edit Certificate Description <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                                    Edit Selected Certificate Description <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                                 </a>
                                             </div>
                                         }
@@ -197,8 +268,8 @@
                             <tr>
                                 <td class="col-7 no-padding">
                                     <div class="accordion" id="@divKey">
-                                        <button class="btn btn-link collapsed text-wrap text-left no-padding" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="collapseOne">
-                                            @c.CompetencyNameEng / @c.CompetencyNameFre
+                                        <button class="btn btn-link collapsed text-wrap text-left no-padding" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="collapseOne" id="competencyScroll-@c.CompetencyId">
+                                            @c.CompetencyNameEng <b>/</b> @c.CompetencyNameFre
                                         </button>
                                         <div id="@key1" class="collapse" aria-labelledby="headingFour" data-parent="#@divKey">
                                             <div class="card-body">
@@ -292,5 +363,7 @@
 </div>
 
 <div>
-    <a asp-page="./Index">Back to List</a>
+    <a asp-page="./Index">Back to List</a> |
+    <a href="/Similar/Locate?id=@Model.Position.JobTitleId">Locate in Similar Positions</a> |
+    <a asp-page="./Delete" asp-route-id="@Model.Position.JobTitleId">Delete</a>
 </div>

--- a/Admin/Pages/Positions/Edit.cshtml
+++ b/Admin/Pages/Positions/Edit.cshtml
@@ -17,10 +17,11 @@
 <div class="space-tables-vertically">
     <div class="row">
         <div class="col-md-12">
-            <form method="post">
-    
+            <form method="post" class="trimFormWhenSubmitting">
+                <input type="hidden" asp-for="JobPosition.Id" />
+
                 <partial name="_Position" model="Model" />
-                @* Create a new position with the same details as current selection*@
+
                 <div class="form-group space-btns">
                     <button class="btn btn-primary" asp-page-handler="create" asp-all-route-data="routedata">Save Changes</button>
                     <a class="btn btn-info" href="/Positions/Create?id=@Model.Id"

--- a/Admin/Pages/Positions/Edit.cshtml.cs
+++ b/Admin/Pages/Positions/Edit.cshtml.cs
@@ -22,12 +22,14 @@ namespace Admin.Pages.Positions
 
         private readonly JobCompetencyService _jobCompetencyService;
         private readonly JobCertificateService _jobCertificateService;
+        private readonly JobPositionService _jobPositionService;
 
-        public EditModel(CctDbContext context, JobCompetencyService jobCompetencyService, JobCertificateService jobCertificateService)
+        public EditModel(CctDbContext context, JobCompetencyService jobCompetencyService, JobCertificateService jobCertificateService, JobPositionService jobPositionService)
         {
             _context = context;
             _jobCompetencyService = jobCompetencyService;
             _jobCertificateService = jobCertificateService;
+            _jobPositionService = jobPositionService;
         }
 
         [BindProperty]
@@ -37,14 +39,7 @@ namespace Admin.Pages.Positions
         public JobCompetencyDto[] JobCompetenciesTechnical { get; set; }
         public JobCompetencyDto[] JobCompetenciesBehavioural { get; set; }
         public JobCompetencyDto[] JobCompetenciesExecutive { get; set; }
-        [BindProperty(SupportsGet = true)]
-        public string TitleEng { get; set; } = string.Empty;
-        [BindProperty(SupportsGet = true)]
-        public string TitleFre { get; set; } = string.Empty;
-        [BindProperty(SupportsGet = true)]
-        public string DescriptionEng { get; set; } = string.Empty;
-        [BindProperty(SupportsGet = true)]
-        public string DescriptionFre { get; set; } = string.Empty;
+
         public List<JobCompetencyRatingDto[]> PositionCompetencyRatings { get; set; } = new List<JobCompetencyRatingDto[]>();
         public List<JobCompetencyRatingDto> AddedKnowledgeCompetencies = new List<JobCompetencyRatingDto>() { };
         public List<JobCompetencyRatingDto> AddedTechnicalCompetencies = new List<JobCompetencyRatingDto>() { };
@@ -79,7 +74,6 @@ namespace Admin.Pages.Positions
         public string JobHLCategory { get; set; } = string.Empty;
 
         [BindProperty]
-        [CheckOneRegionSelected]
         public List<string> SelectedRegionIds { get; set; } = new List<string> { };
 
         [BindProperty(SupportsGet = true)]
@@ -91,6 +85,94 @@ namespace Admin.Pages.Positions
         [BindProperty(SupportsGet = true)]
         public string LevelValue { get; set; }
 
+        private async Task ValidateModel()
+        {
+            var errEng = await CheckUniquePositionName(JobPosition);
+            if (errEng != null)
+            {
+                ModelState.AddModelError("JobPosition.TitleEng", errEng);
+            }
+            var errFre = await CheckUniquePositionName(JobPosition, false);
+            if (errFre != null)
+            {
+                ModelState.AddModelError("JobPosition.TitleFre", errFre);
+            }
+
+            bool oneRegionSelected = !string.IsNullOrWhiteSpace(RegionIds);
+
+            bool atLeastOneComp = (
+                (!string.IsNullOrWhiteSpace(AddedKnowledgeCompetencyIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedTechnicalCompetencyIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedBehaviouralCompetencyIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedExecutiveCompetencyIds))
+                );
+
+            if (!atLeastOneComp)
+            {
+                ModelState.AddModelError("AddedBehaviouralCompetencyIds", "Make sure that at least one competency has been added");
+            }
+
+            if (!oneRegionSelected)
+            {
+                ModelState.AddModelError("SelectedRegionIds", "Make sure that at least one region is selected");
+            }
+        }
+
+        public async Task<List<JobPositionDto>> GetAllJobs()
+        {
+            return (await _jobPositionService.GetAllJobPositions()).ToList();
+        }
+
+        private async Task<string> CheckUniquePositionName(JobPosition position, bool checkEnglish = true)
+        {
+            if (position == null)
+            {
+                return null;
+            }
+
+            var pos = position;
+
+            var positionsOfLevel = (await GetAllJobs()).Where(x => x.LevelCode.ToLower() == LevelCode.ToLower()).ToList();
+
+            if (positionsOfLevel.Any())
+            {
+                var activeJobs = positionsOfLevel.Where(x => x.Active == 1 && x.JobTitleId != pos.Id).ToList();
+                var inactiveJobs = positionsOfLevel.Where(x => x.Active == 0 && x.JobTitleId != pos.Id).ToList();
+
+                if (checkEnglish)
+                {
+                    if (!string.IsNullOrWhiteSpace(pos.TitleEng))
+                    {
+                        if (activeJobs.Select(x => x.JobTitleEng.ToLowerInvariant()).Contains(pos.TitleEng.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that English title";
+                        }
+                        else if (inactiveJobs.Select(x => x.JobTitleEng.ToLowerInvariant()).Contains(pos.TitleEng.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that English title, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                        }
+                    }
+                }
+                else
+                {
+                    if (!string.IsNullOrWhiteSpace(pos.TitleFre))
+                    {
+                        if (activeJobs.Select(x => x.JobTitleFre.ToLowerInvariant()).Contains(pos.TitleFre.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that French title";
+                        }
+                        else if (inactiveJobs.Select(x => x.JobTitleFre.ToLowerInvariant()).Contains(pos.TitleFre.ToLowerInvariant()))
+                        {
+                            return "A position in the level " + LevelCode.ToUpper() + " already has that French title, but it was deleted. " +
+                            "If you wish to enable it once again, contact technical support";
+                        }
+                    }
+                }
+            }
+
+            return null;
+        }
         public Dictionary<string, string> GetRouteData(EditModel model = null)
         {
             EditModel modelObj = model;
@@ -100,10 +182,6 @@ namespace Admin.Pages.Positions
             }
             return new Dictionary<string, string> {
                         {"id", modelObj.Id.ToString() },
-                        {"titleeng", modelObj.TitleEng },
-                        {"titlefre", modelObj.TitleFre },
-                        {"descriptioneng", modelObj.DescriptionEng },
-                        {"descriptionfre", modelObj.DescriptionFre },
                         {"levelcode", modelObj.LevelCode },
                         {"levelvalue", modelObj.LevelValue },
                         {"jobhlcategory", modelObj.JobHLCategory },
@@ -116,22 +194,22 @@ namespace Admin.Pages.Positions
                         {"addedtechnicalcompetencyids", modelObj.AddedTechnicalCompetencyIds },
                         {"addedbehaviouralcompetencyids", modelObj.AddedBehaviouralCompetencyIds },
                         {"addedexecutivecompetencyids", modelObj.AddedExecutiveCompetencyIds },
-                    };
+            };
         }
 
-        public async Task<List<DataModel.CompetencyRatingLevel>> GetCompetencyLevelDescriptions()
+        public async Task<List<CompetencyRatingLevel>> GetCompetencyLevelDescriptions()
         {
             return await _context.CompetencyRatingLevels.ToListAsync();
         }
 
-        public async Task<List<DataModel.CompetencyLevelRequirement>> GetCompetencyDescriptions(int compId)
+        public async Task<List<CompetencyLevelRequirement>> GetCompetencyDescriptions(int compId)
         {
             var levelReqIds = await _context.CompetencyRatingGroups.Where(x => x.CompetencyId == compId)
                                         .OrderBy(x => x.CompetencyLevelRequirementId).ToListAsync();
             var compDescs = await _context.CompetencyLevelRequirements
                                     .Where(x => levelReqIds.Select(x => x.CompetencyLevelRequirementId).ToList().Contains(x.Id))
                                     .ToListAsync();
-            var orderedCompDescs = new List<DataModel.CompetencyLevelRequirement>();
+            var orderedCompDescs = new List<CompetencyLevelRequirement>();
             for (int i = 0; i < levelReqIds.Count(); i++)
             {
                 orderedCompDescs.Add(compDescs.Where(x => x.Id == levelReqIds.ElementAt(i).CompetencyLevelRequirementId).First());
@@ -139,6 +217,170 @@ namespace Admin.Pages.Positions
             // the goal is to get the five different competency level descriptions, in the order of the level (without assuming that
             // those five descriptions are entered in the database in the order of the levels)
             return compDescs;
+        }
+
+        private async Task PreparePageModel(int compIdToIgnore = 0, int certIdToIgnore = 0)
+        {
+            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
+            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
+            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
+            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
+
+            JobCertificates = await _jobCompetencyService.GetJobCertificates();
+            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
+
+            JobGroups = await _jobCompetencyService.GetJobGroups();
+
+            if (!_context.JobGroups.Select(x => x.Id).Contains(JobGroupId))
+            {
+                JobGroupId = JobGroups[0].Id;
+            }
+
+            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
+            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
+            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
+            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
+            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
+
+            var acceptedRegionsIds = await _context.JobLocationRegions.Where(x => x.Active == 1).Select(x => x.Id).ToListAsync();
+            RegionIds = string.Empty;
+            foreach (var id in SelectedRegionIds.Distinct().ToList())
+            {
+                int regionInt = 0;
+                try
+                {
+                    regionInt = int.Parse(id);
+                }
+                catch
+                {
+                    regionInt = 0;
+                }
+
+                if (acceptedRegionsIds.Contains(regionInt))
+                {
+                    RegionIds += id + "-";
+                }
+            }
+
+            string[] compIdsArray = { AddedKnowledgeCompetencyIds, AddedTechnicalCompetencyIds,
+                AddedBehaviouralCompetencyIds, AddedExecutiveCompetencyIds};
+            List<JobCompetencyRatingDto>[] compsArray = { AddedKnowledgeCompetencies, AddedTechnicalCompetencies,
+                AddedBehaviouralCompetencies, AddedExecutiveCompetencies };
+
+            for (int i = 0; i < compIdsArray.Length; i++)
+            {
+                var ids = compIdsArray[i];
+                var compType = compsArray[i];
+
+                foreach (var cid in ids.Split("-").Distinct())
+                {
+                    if (!string.IsNullOrEmpty(cid))
+                    {
+                        if (cid.Contains("&"))
+                        {
+                            var cidc = cid.Split("&")[0];
+                            var clevel = cid.Split("&")[1];
+
+                            if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
+                            {
+                                try
+                                {
+                                    var cidInt = int.Parse(cidc);
+                                    if (cidInt != compIdToIgnore)
+                                    {
+                                        var cLevel = int.Parse(clevel);
+                                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
+                                        if (competency != null)
+                                        {
+                                            if (competency.Active == 1)
+                                            {
+                                                compType.Add(competency);
+                                            }
+                                        }
+                                    }
+                                }
+                                catch
+                                {
+                                    compIdToIgnore = -10;
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            if (compIdToIgnore != 0)
+            {
+                AddedKnowledgeCompetencyIds = string.Empty;
+                AddedTechnicalCompetencyIds = string.Empty;
+                AddedBehaviouralCompetencyIds = string.Empty;
+                AddedExecutiveCompetencyIds = string.Empty;
+                foreach (var competency in AddedKnowledgeCompetencies)
+                {
+                    AddedKnowledgeCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
+                }
+                foreach (var competency in AddedTechnicalCompetencies)
+                {
+                    AddedTechnicalCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
+                }
+                foreach (var competency in AddedBehaviouralCompetencies)
+                {
+                    AddedBehaviouralCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
+                }
+                foreach (var competency in AddedExecutiveCompetencies)
+                {
+                    AddedExecutiveCompetencyIds += competency.CompetencyId + "&" + (competency.RatingValue + 5) + "-";
+                }
+            }
+
+            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
+            {
+                if (!string.IsNullOrEmpty(cid))
+                {
+                    if (cid.Contains("&"))
+                    {
+                        try
+                        {
+                            var cidInt = int.Parse(cid.Split("&")[0]);
+                            if (cidInt != certIdToIgnore)
+                            {
+                                var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
+                                if (certificateDto != null)
+                                {
+                                    if (certificateDto.Active == 1)
+                                    {
+                                        var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
+                                        if (certificateDescDto != null)
+                                        {
+                                            certificateDto.CertificateDescId = certificateDescDto.Id;
+                                            if (certificateDescDto.Active == 1)
+                                            {
+                                                certificateDto.DescEng = certificateDescDto.DescEng;
+                                                certificateDto.DescFre = certificateDescDto.DescFre;
+                                            }
+                                            AddedCertificates.Add(certificateDto);
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        catch
+                        {
+                            certIdToIgnore = -10;
+                        }
+                    }
+                }
+            }
+            if (certIdToIgnore != 0)
+            {
+                AddedCertificateIds = string.Empty;
+                foreach (var certificate in AddedCertificates)
+                {
+                    AddedCertificateIds += certificate.Id + "&" + certificate.CertificateDescId + "-";
+                }
+            }
+
+            await ValidateModel();
         }
 
         public async Task<IActionResult> OnGetAsync(int? id)
@@ -156,11 +398,6 @@ namespace Admin.Pages.Positions
             {
                 return NotFound();
             }
-
-            TitleEng = JobPosition.TitleEng;
-            TitleFre = JobPosition.TitleFre;
-            DescriptionEng = JobPosition.PositionDescEng;
-            DescriptionFre = JobPosition.PositionDescFre;
 
             CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(id.Value);
             var PositionCertificates = await _jobCompetencyService.GetJobCertificatesById(id.Value);
@@ -192,57 +429,42 @@ namespace Admin.Pages.Positions
                     }
                 }
             }
-            var competenciesType1 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 1);
-            if (competenciesType1 != null)
-            {
-                foreach (var competency in competenciesType1)
-                {
-                    if (competency != null)
-                    {
-                        AddedKnowledgeCompetencyIds += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
-                        AddedKnowledgeCompetencies.Add(competency);
-                    }
-                }
-            }
 
-            var competenciesType2 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 2);
-            if (competenciesType2 != null)
-            {
-                foreach (var competency in competenciesType2)
-                {
-                    if (competency != null)
-                    {
-                        AddedTechnicalCompetencyIds += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
-                        AddedTechnicalCompetencies.Add(competency);
-                    }
-                }
-            }
-            var competenciesType3 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 3);
-            if (competenciesType3 != null)
-            {
-                foreach (var competency in competenciesType3)
-                {
-                    if (competency != null)
-                    {
-                        AddedBehaviouralCompetencyIds += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
-                        AddedBehaviouralCompetencies.Add(competency);
-                    }
-                }
-            }
-            var competenciesType4 = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, 4);
-            if (competenciesType4 != null)
-            {
-                foreach (var competency in competenciesType4)
-                {
-                    if (competency != null)
-                    {
-                        AddedExecutiveCompetencyIds += competency.CompetencyId + "&" + (competency.CompetencyRatingLevelId + 
-                            (competency.CompetencyRatingLevelId <= 5 ? 5 : 0)) + "-";
-                        AddedExecutiveCompetencies.Add(competency);
-                    }
-                }
-            }
+            string[] compIdsArray = new string[4];
+            List<JobCompetencyRatingDto>[] compsArray = { AddedKnowledgeCompetencies, AddedTechnicalCompetencies,
+                    AddedBehaviouralCompetencies, AddedExecutiveCompetencies};
 
+            for (int i = 0; i < compIdsArray.Length; i++)
+            {
+                bool exec = (i == compsArray.Length - 1);
+
+                var compType = compsArray[i];
+
+                var competenciesOfType = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(id.Value, i + 1);
+                if (competenciesOfType != null)
+                {
+                    foreach (var competency in competenciesOfType)
+                    {
+                        if (competency != null)
+                        {
+                            if (!exec)
+                            {
+                                compIdsArray[i] += competency.CompetencyId + "&" + competency.CompetencyRatingLevelId + "-";
+                            }
+                            else
+                            {
+                                compIdsArray[i] += competency.CompetencyId + "&" + (competency.CompetencyRatingLevelId +
+                                    (competency.CompetencyRatingLevelId <= 5 ? 5 : 0)) + "-";
+                            }
+                            compType.Add(competency);
+                        }
+                    }
+                }
+            }
+            AddedKnowledgeCompetencyIds = compIdsArray[0];
+            AddedTechnicalCompetencyIds = compIdsArray[1];
+            AddedBehaviouralCompetencyIds = compIdsArray[2];
+            AddedExecutiveCompetencyIds = compIdsArray[3];
 
             JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
             JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
@@ -257,773 +479,72 @@ namespace Admin.Pages.Positions
             SubJobGroupId = CurrentJobPosition.SubJobGroupId;
             JobGroupLevelId = CurrentJobPosition.JobGroupLevelId;
             LevelCode = CurrentJobPosition.LevelCode;
-            return Page();
 
+            return Page();
         }
+
         public async Task OnPostGroup()
         {
-            JobPosition = await _context.JobPositions.FirstOrDefaultAsync(m => m.Id == Id);
-            CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(Id);
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
-                    certificateDto.CertificateDescId = certificateDescDto.Id;
-                    if (certificateDescDto.Active == 1)
-                    {
-                        certificateDto.DescEng = certificateDescDto.DescEng;
-                        certificateDto.DescFre = certificateDescDto.DescFre;
-                    }
-                    AddedCertificates.Add(certificateDto);
-                }
-            }
-
+            await PreparePageModel();
         }
+
         public async Task OnPostCertificate()
         {
-            JobPosition = await _context.JobPositions.FirstOrDefaultAsync(m => m.Id == Id);
-            CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(Id);
             var certificate = Request.Form["certificate"];
             var certificatedescId = Request.Form["CertificateDescriptionId"];
-            AddedCertificateIds += certificate[0] + "&" + certificatedescId[0] + "-";
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
+            if (certificate != Microsoft.Extensions.Primitives.StringValues.Empty
+                && certificatedescId != Microsoft.Extensions.Primitives.StringValues.Empty)
             {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
-                    certificateDto.CertificateDescId = certificateDescDto.Id;
-                    if (certificateDescDto.Active == 1)
-                    {
-                        certificateDto.DescEng = certificateDescDto.DescEng;
-                        certificateDto.DescFre = certificateDescDto.DescFre;
-                    }
-                    AddedCertificates.Add(certificateDto);
-                }
+                AddedCertificateIds += certificate[0] + "&" + certificatedescId[0] + "-";
             }
 
+            await PreparePageModel();
         }
+
         public async Task OnPostCompetency(string competencytypename)
         {
-            JobPosition = await _context.JobPositions.FirstOrDefaultAsync(m => m.Id == this.Id);
-            CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(this.Id);
             var Id = Request.Form[$"{competencytypename}Competency"];
             var level = Request.Form[$"{competencytypename}Level"];
-            TitleEng = Request.Form["titleEng"];
-            TitleFre = Request.Form["titleFre"];
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            if (competencytypename == "knowledge")
-            {
-                AddedKnowledgeCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            else if (competencytypename == "technical")
-            {
-                AddedTechnicalCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            else if (competencytypename == "behavioural")
-            {
-                AddedBehaviouralCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            else if (competencytypename == "executive")
-            {
-                AddedExecutiveCompetencyIds += Id[0] + "&" + level[0] + "-";
-            }
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
+            if (Id != Microsoft.Extensions.Primitives.StringValues.Empty
+                && level != Microsoft.Extensions.Primitives.StringValues.Empty)
             {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
+                var strToAdd = Id[0] + "&" + level[0] + "-";
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
+                if (competencytypename == "knowledge")
+                {
+                    AddedKnowledgeCompetencyIds += strToAdd;
+                }
+                else if (competencytypename == "technical")
+                {
+                    AddedTechnicalCompetencyIds += strToAdd;
+                }
+                else if (competencytypename == "behavioural")
+                {
+                    AddedBehaviouralCompetencyIds += strToAdd;
+                }
+                else if (competencytypename == "executive")
+                {
+                    AddedExecutiveCompetencyIds += strToAdd;
                 }
             }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
 
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
-                    certificateDto.CertificateDescId = certificateDescDto.Id;
-                    if (certificateDescDto.Active == 1)
-                    {
-                        certificateDto.DescEng = certificateDescDto.DescEng;
-                        certificateDto.DescFre = certificateDescDto.DescFre;
-                    }
-                    AddedCertificates.Add(certificateDto);
-                }
-            }
+            await PreparePageModel();
         }
 
         public async Task OnPostDeleteCertificate(int certificateid)
         {
-            JobPosition = await _context.JobPositions.FirstOrDefaultAsync(m => m.Id == Id);
-            CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(Id);
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            TitleEng = Request.Form["titleEng"];
-            TitleFre = Request.Form["titleFre"];
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedCertificateIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    if (cidInt != certificateid)
-                    {
-                        var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                        var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
-                        certificateDto.CertificateDescId = certificateDescDto.Id;
-                        if (certificateDescDto.Active == 1)
-                        {
-                            certificateDto.DescEng = certificateDescDto.DescEng;
-                            certificateDto.DescFre = certificateDescDto.DescFre;
-                        }
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
-
-            AddedCertificateIds = string.Empty;
-            foreach (var certificate in AddedCertificates)
-            {
-                AddedCertificateIds += certificate.Id + "&" + certificate.CertificateDescId + "-";
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-
+            await PreparePageModel(0, certificateid);
         }
+
         public async Task OnPostDelete(int competencyid)
         {
-            JobPosition = await _context.JobPositions.FirstOrDefaultAsync(m => m.Id == Id);
-            CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(Id);
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            TitleEng = Request.Form["titleEng"];
-            TitleFre = Request.Form["titleFre"];
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            SubJobGroupId = int.Parse(LevelValue.Split("/")[0]);
-            JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]);
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            foreach (var id in SelectedRegionIds)
-            {
-                RegionIds += id + "-";
-            }
-            foreach (var cid in AddedCertificateIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    var certificateDescDto = await _jobCertificateService.GetJobCertificateDescriptionById(int.Parse(cid.Split("&")[1]));
-                    certificateDto.CertificateDescId = certificateDescDto.Id;
-                    if (certificateDescDto.Active == 1)
-                    {
-                        certificateDto.DescEng = certificateDescDto.DescEng;
-                        certificateDto.DescFre = certificateDescDto.DescFre;
-                    }
-                    AddedCertificates.Add(certificateDto);
-                }
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedKnowledgeCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedBehaviouralCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedTechnicalCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-"))
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        if (cidInt != competencyid)
-                        {
-                            var cLevel = int.Parse(clevel);
-                            var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                            if (competency != null)
-                            {
-                                AddedExecutiveCompetencies.Add(competency);
-                            }
-                        }
-                    }
-                }
-            }
-            AddedKnowledgeCompetencyIds = string.Empty;
-            AddedTechnicalCompetencyIds = string.Empty;
-            AddedBehaviouralCompetencyIds = string.Empty;
-            AddedExecutiveCompetencyIds = string.Empty;
-            foreach (var competency in AddedKnowledgeCompetencies)
-            {
-                AddedKnowledgeCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
-            }
-            foreach (var competency in AddedTechnicalCompetencies)
-            {
-                AddedTechnicalCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
-            }
-            foreach (var competency in AddedBehaviouralCompetencies)
-            {
-                AddedBehaviouralCompetencyIds += competency.CompetencyId + "&" + competency.RatingValue + "-";
-            }
-            foreach (var competency in AddedExecutiveCompetencies)
-            {
-                AddedExecutiveCompetencyIds += competency.CompetencyId + "&" + (competency.RatingValue + 5) + "-";
-            }
+            await PreparePageModel(competencyid);
         }
-        public async Task<IActionResult> OnPostCreateAsync()
+
+        private async Task RemoveOldRanges()
         {
-            JobPosition = await _context.JobPositions.FirstOrDefaultAsync(m => m.Id == Id);
-            CurrentJobPosition = await _jobCompetencyService.GetJobPositionById(Id);
-            JobCertificates = await _jobCompetencyService.GetJobCertificates();
-            JobCompetenciesKnowledge = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
-            JobCompetenciesTechnical = await _jobCompetencyService.GetJobCompetenciesByTypeId(2);
-            JobCompetenciesBehavioural = await _jobCompetencyService.GetJobCompetenciesByTypeId(3);
-            JobCompetenciesExecutive = await _jobCompetencyService.GetJobCompetenciesByTypeId(4);
-            CurrentSelectedJobGroup = await _jobCompetencyService.GetJobGroupById(JobGroupId);
-            JobGroupPositions = await _jobCompetencyService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobCompetencyService.GetJobGroups();
-            JobCertificateDescriptions = await _jobCompetencyService.GetAllJobCertificateDescriptions();
-            LevelCode = LevelValue.Split("/")[2];
-            RegionIds = string.Empty;
-            var acceptedRegionIds = _context.JobLocationRegions.Select(x => x.Id).ToList();
-            foreach (var id in SelectedRegionIds.Distinct())
-            {
-                if (int.TryParse(id, out int intId))
-                {
-                    if (acceptedRegionIds.Contains(intId)) {
-                        RegionIds += id + "-";
-                    }
-                }
-            }
-            foreach (var cid in AddedKnowledgeCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedKnowledgeCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedTechnicalCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedTechnicalCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedBehaviouralCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedBehaviouralCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedExecutiveCompetencyIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidc = cid.Split("&")[0];
-                    var clevel = cid.Split("&")[1];
-
-                    if (!string.IsNullOrEmpty(cidc) && !string.IsNullOrEmpty(clevel))
-                    {
-                        var cidInt = int.Parse(cidc);
-                        var cLevel = int.Parse(clevel);
-                        var competency = await _jobCompetencyService.GetJobCompetencyLevelByIdLevelId(cidInt, cLevel);
-                        if (competency != null)
-                        {
-                            AddedExecutiveCompetencies.Add(competency);
-                        }
-                    }
-                }
-            }
-            foreach (var cid in AddedCertificateIds.Split("-").Distinct())
-            {
-                if (!string.IsNullOrEmpty(cid))
-                {
-                    var cidInt = int.Parse(cid.Split("&")[0]);
-                    var certificateDto = await _jobCompetencyService.GetJobCertificateById(cidInt);
-                    if (certificateDto != null)
-                    {
-                        certificateDto.CertificateDescId = int.Parse(cid.Split("&")[1]);
-                        AddedCertificates.Add(certificateDto);
-                    }
-                }
-            }
-
-            if (!ModelState.IsValid) // the model can't be validated right at the beginning of this function, otherwise the DTO
-                                     // won't be in the proper state, since its properties won't have been set, yet
-            {
-                return Page();
-            }
-
             var jobgrouppositions = _context.JobGroupPositions.Where(e => e.JobPositionId == JobPosition.Id).ToList();
             _context.JobGroupPositions.RemoveRange(jobgrouppositions);
             var jobrolepositioncertificates = _context.JobRolePositionCertificates.Where(e => e.JobPositionId == JobPosition.Id).ToList();
@@ -1038,98 +559,136 @@ namespace Admin.Pages.Positions
             _context.JobRolePositionHLCategories.RemoveRange(jobrolepositionhlcategories);
             var jobrolepositionlocations = _context.JobRolePositionLocations.Where(e => e.JobPositionId == JobPosition.Id).ToList();
             _context.JobRolePositionLocations.RemoveRange(jobrolepositionlocations);
-            _context.SaveChanges();
+            await _context.SaveChangesAsync();
+        }
 
-            _jobCompetencyService.UpdateJobPosition(new JobPosition()
+        public async Task<IActionResult> OnPostCreateAsync()
+        {
+            await PreparePageModel();
+
+            if (!ModelState.IsValid) // the model can't be validated right at the beginning of this function, otherwise the DTO
+                                     // won't be in the proper state, since its properties won't have been set, yet
+            {
+                return Page();
+            }
+
+            await RemoveOldRanges();
+
+            await _jobCompetencyService.UpdateJobPosition(new JobPosition()
             {
                 Id = JobPosition.Id,
-                TitleEng = TitleEng,
-                TitleFre = TitleFre,
-                PositionDescEng = DescriptionEng,
-                PositionDescFre = DescriptionFre
+                TitleEng = JobPosition.TitleEng,
+                TitleFre = JobPosition.TitleFre,
+                PositionDescEng = JobPosition.PositionDescEng,
+                PositionDescFre = JobPosition.PositionDescFre
             });
+
+            bool validLevelValue = true;
+
+            if (string.IsNullOrWhiteSpace(LevelValue))
+            {
+                validLevelValue = false;
+            }
+            else
+            {
+                if (!LevelValue.Contains("/"))
+                {
+                    validLevelValue = false;
+                }
+                else
+                {
+                    var splitLevel = LevelValue.Split("/");
+
+                    try
+                    {
+                        int subGroupId = int.Parse(splitLevel[0]);
+                        int jobGroupLevelId = int.Parse(splitLevel[1]);
+                        string code = splitLevel[2];
+
+                        var levelValues = JobGroupPositions.Select(x => x.LevelValue).ToList();
+                        List<int> levelValuesInt = new List<int>();
+
+                        foreach (var value in levelValues)
+                        {
+                            levelValuesInt.Add(int.Parse(value));
+                        }
+
+                        if (!_context.SubJobGroups.Select(x => x.Id).ToList().Contains(subGroupId) ||
+                            !levelValuesInt.Contains(jobGroupLevelId))
+                        {
+                            validLevelValue = false;
+                        }
+                        else
+                        {
+                            var codes = JobGroupPositions.Select(x => x.LevelCode.ToLower()).ToList();
+                            if (!codes.Contains(code.ToLower()))
+                            {
+                                validLevelValue = false;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        validLevelValue = false;
+                    }
+                }
+            }
+
+            if (!validLevelValue)
+            {
+                JobGroupId = JobGroups[0].Id;
+                LevelValue = "25/1/AS-01";
+            }
+
+            int jobPositionId = JobPosition.Id;
+
             var jobGroupPosition = new JobGroupPosition()
             {
                 JobGroupId = JobGroupId,
-                JobPositionId = JobPosition.Id,
+                JobPositionId = jobPositionId,
                 SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
                 JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
             };
-            _jobCompetencyService.PostJobGroupPosition(jobGroupPosition);
-            foreach (var competency in AddedKnowledgeCompetencies)
-            {
-                var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
-                {
-                    JobPositionId = JobPosition.Id,
-                    CompetencyId = competency.CompetencyId,
-                    CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                    CompetencyTypeId = 1,
-                    CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                    SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                    JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                    JobGroupId = JobGroupId
-                };
-                _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-            }
-            foreach (var competency in AddedTechnicalCompetencies)
-            {
-                var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
-                {
-                    JobPositionId = JobPosition.Id,
-                    CompetencyId = competency.CompetencyId,
-                    CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                    CompetencyTypeId = 2,
-                    CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                    SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                    JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                    JobGroupId = JobGroupId
-                };
+            await _jobCompetencyService.PostJobGroupPosition(jobGroupPosition);
 
-                _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-            }
-            foreach (var competency in AddedBehaviouralCompetencies)
+            List<JobCompetencyRatingDto>[] compList = { AddedKnowledgeCompetencies, AddedTechnicalCompetencies,
+            AddedBehaviouralCompetencies, AddedExecutiveCompetencies };
+            for (int i = 0; i < compList.Length; i++)
             {
-                var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
-                {
-                    JobPositionId = JobPosition.Id,
-                    CompetencyId = competency.CompetencyId,
-                    CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                    CompetencyTypeId = 3,
-                    CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                    SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                    JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                    JobGroupId = JobGroupId
-                };
+                var currCompType = compList.ElementAt(i);
 
-                _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-            }
-            foreach (var competency in AddedExecutiveCompetencies)
-            {
-                var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
+                foreach (var competency in currCompType)
                 {
-                    JobPositionId = JobPosition.Id,
-                    CompetencyId = competency.CompetencyId,
-                    CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
-                    CompetencyTypeId = 4,
-                    CompetencyRatingLevelId = competency.CompetencyRatingLevelId,
-                    SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                    JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
-                    JobGroupId = JobGroupId
-                };
+                    var ratingLevelId = competency.CompetencyRatingLevelId - (competency.CompetencyRatingLevelId > 5 ? 5 : 0);
+                    var jobrolepositioncompetency = new JobRolePositionCompetencyRating()
+                    {
+                        JobPositionId = jobPositionId,
+                        CompetencyId = competency.CompetencyId,
+                        CompetencyLevelRequirementId = competency.CompetencyLevelRequirementId,
+                        CompetencyTypeId = i + 1,
+                        CompetencyRatingLevelId = ratingLevelId,
+                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
+                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
+                        JobGroupId = JobGroupId
+                    };
+                    await _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
+                }
+            }
 
-                _jobCompetencyService.PostJobRolePositionCompetency(jobrolepositioncompetency);
-            }
-            foreach (var id in SelectedRegionIds)
+            foreach (var id in RegionIds.Split("-"))
             {
-                var jobrolepositionlocation = new JobRolePositionLocation()
+                if (!string.IsNullOrWhiteSpace(id))
                 {
-                    JobLocationRegionId = int.Parse(id),
-                    JobGroupId = JobGroupId,
-                    JobPositionId = JobPosition.Id,
-                    SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
-                    JobGroupLevelId = int.Parse(LevelValue.Split("/")[1])
-                };
-                _jobCompetencyService.PostJobRolePositionLocation(jobrolepositionlocation);
+                    var jobrolepositionlocation = new JobRolePositionLocation()
+                    {
+                        JobLocationRegionId = int.Parse(id),
+                        JobGroupId = JobGroupId,
+                        JobPositionId = jobPositionId,
+                        SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
+                        JobGroupLevelId = int.Parse(LevelValue.Split("/")[1])
+                    };
+                    await _jobCompetencyService.PostJobRolePositionLocation(jobrolepositionlocation);
+                }
             }
 
             var acceptedHLCategoryIds = _context.JobHLCategories.Select(x => x.Id).ToList();
@@ -1143,30 +702,28 @@ namespace Admin.Pages.Positions
             var jobrolepositionhlcategory = new JobRolePositionHLCategory()
             {
                 JobGroupId = JobGroupId,
-                JobPositionId = JobPosition.Id,
+                JobPositionId = jobPositionId,
                 SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
                 JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
                 JobHLCategoryId = int.Parse(JobHLCategory)
             };
-            _jobCompetencyService.PostJobRolePositionHLCategory(jobrolepositionhlcategory);
+            await _jobCompetencyService.PostJobRolePositionHLCategory(jobrolepositionhlcategory);
+
             foreach (var certificate in AddedCertificates)
             {
                 var jobrolepositioncertificate = new JobRolePositionCertificate()
                 {
-                    JobPositionId = JobPosition.Id,
+                    JobPositionId = jobPositionId,
                     JobGroupId = JobGroupId,
                     SubJobGroupId = int.Parse(LevelValue.Split("/")[0]),
                     JobGroupLevelId = int.Parse(LevelValue.Split("/")[1]),
                     CertificateDescriptionId = certificate.CertificateDescId,
                     CertificateId = certificate.Id,
                 };
-                _jobCompetencyService.PostJobRolePositionCertificate(jobrolepositioncertificate);
-
+                await _jobCompetencyService.PostJobRolePositionCertificate(jobrolepositioncertificate);
             }
 
-            Thread.Sleep(10000);
             return RedirectToPage("Details", new { positionid = JobPosition.Id, });
-
         }
     }
 }

--- a/Admin/Pages/Positions/Index.cshtml
+++ b/Admin/Pages/Positions/Index.cshtml
@@ -5,9 +5,9 @@
 }
 
 <div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
-    <h1>Positions</h1>
+    <h1>Positions <span class="glyphicon glyphicon-save-file pull-right index-save-file-icon" onclick="print()"></span></h1>
     <p>
-        <a class="btn btn-dark" asp-page="Create">Create New</a>
+        <a class="btn btn-dark hide-in-print" asp-page="Create">Create New</a>
     </p>
 
     @{
@@ -26,7 +26,7 @@
         itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
     }
 
-    <form>
+    <form class="hide-in-print">
         <div class="form-actions no-color">
             <h6>
                 <label for="Filter">Find positions:</label>
@@ -47,12 +47,12 @@
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">
-                    <th width="7%"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
-                    <th width="35%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
-                    <th width="35%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
+                    <th width="10%"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                    <th width="37.5%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                    <th width="37.5%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
                     <th width="15%">
                         <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
-                        class="arrow-icon" data-toggle="collapse" data-target="#collapsibleTop" 
+                        class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
                         aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
                         alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
                         title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
@@ -72,10 +72,13 @@
                         <td>
                             @Html.DisplayFor(modelItem => item.JobTitleFre)
                         </td>
-                        <td class="text-center">
+                        <td class="text-center hide-in-print">
                             <a asp-page="Details" asp-route-positionid="@item.JobTitleId">Details</a> |
                             <a asp-page="Edit" asp-route-id="@item.JobTitleId">Edit</a> |
                             <a asp-page="Delete" asp-route-id="@item.JobTitleId">Delete</a>
+                        </td>
+                        <td class="hide-when-not-in-print table-cell text-center">
+                            <a asp-page="Details" asp-route-positionid="@item.JobTitleId" class="print-link underline">Details</a>
                         </td>
                     </tr>
                 }

--- a/Admin/Pages/Positions/Index.cshtml
+++ b/Admin/Pages/Positions/Index.cshtml
@@ -43,7 +43,7 @@
 
 @if (itemsThatMatchFilter.Any())
 {
-    <div id="table-container">
+    <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">

--- a/Admin/Pages/Positions/Index.cshtml.cs
+++ b/Admin/Pages/Positions/Index.cshtml.cs
@@ -22,6 +22,8 @@ namespace Admin.Pages.Positions
 
         public bool DisplayTopOfPage { get; set; }
 
+        public double LastTableContainerHeight { get; set; } = 300;
+
         public IList<JobPositionDto> JobPositions { get; set; }
         [BindProperty(SupportsGet = true)]
         public string Filter { get; set; }
@@ -37,6 +39,17 @@ namespace Admin.Pages.Positions
                 if (sessionStr.ToLower() == "false")
                 {
                     DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
                 }
             }
         }

--- a/Admin/Pages/Shared/_Competency.cshtml
+++ b/Admin/Pages/Shared/_Competency.cshtml
@@ -56,10 +56,6 @@
                         {
                             var routedataremoveall = new Dictionary<string, string> {
                                 {"id", FullPageModel.Id.ToString() },
-                                {"titleeng", FullPageModel.TitleEng },
-                                {"titlefre", FullPageModel.TitleFre },
-                                {"descriptioneng", FullPageModel.DescriptionEng },
-                                {"descriptionfre", FullPageModel.DescriptionFre },
                                 {"levelcode", FullPageModel.LevelCode },
                                 {"levelvalue", FullPageModel.LevelValue },
                                 {"regionids", FullPageModel.RegionIds },
@@ -140,12 +136,12 @@
                         <div class="modal-body">
                             <div class="card-body table-header-row">
                                 <div class="row">
-                                    <div class="col-9 mb-3">
+                                    <div class="col-10 mb-3">
                                         <label class="control-label" for="@(Model.FullCompetencyNameOneWord.ToLower() + "Competency")"><b>@Model.FullCompetencyNameEng / @Model.FullCompetencyNameFre</b></label><br />
                                         <select class="form-control dropdown-toggle mrgn-bttm-md" id="@(Model.FullCompetencyNameOneWord.ToLower() + "Competency")" name="@(Model.FullCompetencyNameOneWord.ToLower() + "Competency")">
                                             @foreach (var competency in remainingCompetenciesToAdd)
                                             {
-                                                <option value="@competency.Id">@competency.NameEng</option>
+                                                <option value="@competency.Id">@competency.NameEng <b>/</b> @competency.NameFre</option>
                                             }
                                         </select>
                                     </div>
@@ -161,9 +157,9 @@
                                     </div>
                                 </div>
                             </div>
-                            <div class="modal-footer">
+                            <div class="modal-footer no-padding-bottom no-padding-right">
                                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                                <button class="btn btn-primary text-left resetWindowHeight" asp-page-handler="competency" asp-all-route-data="@Model.RouteDataForCompetency">Save Changes</button>
+                                <button class="btn btn-primary text-left resetWindowHeight" asp-page-handler="competency" asp-all-route-data="@Model.RouteDataForCompetency">Add Competency</button>
                             </div>
                         </div>
                     </div>
@@ -182,8 +178,8 @@
                     <div class="row">
                         <div class="col-6">
                             <div class="accordion" id="@divKey">
-                                <button class="btn btn-link collapsed text-wrap text-left" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="@key1">
-                                    @competency.CompetencyNameEng / @competency.CompetencyNameFre
+                                <button class="btn btn-link collapsed text-wrap text-left" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="@key1" id="competencyScroll-@competency.CompetencyId">
+                                    @competency.CompetencyNameEng <b>/</b> @competency.CompetencyNameFre
                                 </button>
                                 <div id="@key1" class="collapse" aria-labelledby="#@("tableTitle_" + Model.FullCompetencyNameOneWord)" data-parent="#@divKey">
                                     <div class="card-body">
@@ -267,10 +263,6 @@
                             @{
                                 var routedataremove = new Dictionary<string, string> {
                                     {"id", FullPageModel.Id.ToString() },
-                                    {"titleeng", FullPageModel.TitleEng },
-                                    {"titlefre", FullPageModel.TitleFre },
-                                    {"descriptioneng", FullPageModel.DescriptionEng },
-                                    {"descriptionfre", FullPageModel.DescriptionFre },
                                     {"levelcode", FullPageModel.LevelCode },
                                     {"levelvalue", FullPageModel.LevelValue },
                                     {"regionids", FullPageModel.RegionIds },

--- a/Admin/Pages/Shared/_Layout.cshtml
+++ b/Admin/Pages/Shared/_Layout.cshtml
@@ -16,7 +16,7 @@
 <body>
     <header>
         <nav class="navbar navbar-expand-sm rememberIfVisited navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3 no-padding">
-            <div class="container">
+            <div class="container nav-container">
                 <a class="navbar-brand smooth-underline" asp-area="" asp-page="/Index">CCG CCT Admin</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
@@ -37,6 +37,12 @@
                             <a class="nav-link rememberIfVisited" href="/Positions">Positions</a>
                         </li>
                         <li class="nav-item" id="navCompetencies">
+                            <div class="dropdown-content">
+                                <a href="/Competencies/List?typeid=1" class="nav-link smooth-underline">Knowledge</a>
+                                <a href="/Competencies/List?typeid=2" class="nav-link smooth-underline">Technical</a>
+                                <a href="/Competencies/List?typeid=3" class="nav-link smooth-underline">Behavioural</a>
+                                <a href="/Competencies/List?typeid=4" class="nav-link smooth-underline">Executive</a>
+                            </div>
                             <a class="nav-link rememberIfVisited" href="/Competencies/List?typeid=1">Competencies</a>
                         </li>
                         <li class="nav-item" id="navSimilar">
@@ -44,6 +50,12 @@
                         </li>
                     </ul>
                 </div>
+            </div>
+            <div id="navHider">
+            </div>
+            <div id="bottomNavHider">
+            </div>
+            <div id="compNavHider">
             </div>
         </nav>
     </header>

--- a/Admin/Pages/Shared/_Position.cshtml
+++ b/Admin/Pages/Shared/_Position.cshtml
@@ -1,6 +1,8 @@
 ﻿@model Admin.Pages.Positions.EditModel
 @using Admin.Data.PartialModels
 @using Business.Dtos.JobCompetencies
+@using System.Text.RegularExpressions
+@inject Admin.Data.FormattingService Formatter
 
 @{
     bool expandableItemsOpenNewWindows = true;
@@ -21,7 +23,6 @@
 }
 
 <div asp-validation-summary="ModelOnly" class="text-danger"></div>
-<input type="hidden" asp-for="JobPosition.Id" />
 
 <table class="table table-bordered">
     <thead>
@@ -33,13 +34,13 @@
         <tr>
             <td>
                 <div class="form-group m-2">
-                    <label class="control-label" for="titleEng"><b>Title English</b></label>
-                    <textarea class="form-control" name="titleEng" required id="titleEng">@Model.TitleEng</textarea>
+                    <label class="control-label" asp-for="JobPosition.TitleEng"><b>Title English</b></label>
+                    <textarea class="form-control" asp-for="JobPosition.TitleEng" required></textarea>
                     <span asp-validation-for="JobPosition.TitleEng" class="text-danger"></span>
                 </div>
                 <div class="form-group m-2">
-                    <label class="control-label" for="titleFre"><b>Title French</b></label>
-                    <textarea class="form-control" name="titleFre" required id="titleFre">@Model.TitleFre</textarea>
+                    <label class="control-label" asp-for="JobPosition.TitleFre"><b>Title French</b></label>
+                    <textarea class="form-control" asp-for="JobPosition.TitleFre" required></textarea>
                     <span asp-validation-for="JobPosition.TitleFre" class="text-danger"></span>
                 </div>
             </td>
@@ -47,13 +48,13 @@
         <tr>
             <td>
                 <div class="form-group m-2">
-                    <label class="control-label" for="descEng"><b>Description English</b></label>
-                    <textarea class="form-control" name="descriptionEng" id="descEng">@Model.DescriptionEng</textarea>
+                    <label class="control-label" asp-for="JobPosition.PositionDescEng"><b>Description English</b></label>
+                    <textarea class="form-control" asp-for="JobPosition.PositionDescEng"></textarea>
                     <span asp-validation-for="JobPosition.PositionDescEng" class="text-danger"></span>
                 </div>
                 <div class="form-group m-2">
-                    <label class="control-label" for="descFre"><b>Description French</b></label>
-                    <textarea class="form-control" name="descriptionFre" id="descFre">@Model.DescriptionFre</textarea>
+                    <label class="control-label" asp-for="JobPosition.PositionDescFre"><b>Description French</b></label>
+                    <textarea class="form-control" asp-for="JobPosition.PositionDescFre"></textarea>
                     <span asp-validation-for="JobPosition.PositionDescFre" class="text-danger"></span>
                 </div>
             </td>
@@ -102,6 +103,9 @@
         </tr>
     </tbody>
 </table>
+
+<span asp-validation-for="SelectedRegionIds" style="padding-bottom: 6px" 
+class="text-danger display-block small-margin-bottom no-padding-top bold"></span>
 
 <table class="table table-bordered">
     <thead>
@@ -213,8 +217,6 @@
     </tbody>
 </table>
 
-<span asp-validation-for="SelectedRegionIds"></span>
-
 <table class="table table-bordered">
     <thead>
         <tr>
@@ -231,7 +233,7 @@
                         <button class="form-control dropdown-toggle mrgn-bttm-md" id="menu1" type="button" data-toggle="dropdown">
                             (@Model.CurrentSelectedJobGroup.Code) @Model.CurrentSelectedJobGroup.NameEng / @Model.CurrentSelectedJobGroup.NameFre
                         </button>
-                        <ul class="dropdown-menu" role="menu" aria-labelledby="menu1">
+                        <ul class="dropdown-menu limit-height" role="menu" aria-labelledby="menu1">
                             @{
                                 var jobGroups = Model.JobGroups.OrderBy(x => x.Code.ToLower()).Distinct().ToList();
                             }
@@ -239,10 +241,6 @@
                             {
                                 var routedatagroup = new Dictionary<string, string> {
                                         {"id", Model.Id.ToString() },
-                                        {"titleeng", Model.TitleEng },
-                                        {"titlefre", Model.TitleFre },
-                                        {"descriptioneng", Model.DescriptionEng },
-                                        {"descriptionfre", Model.DescriptionFre },
                                         {"levelcode", Model.LevelCode },
                                         {"levelvalue", Model.LevelValue },
                                         {"regionids", Model.RegionIds },
@@ -331,10 +329,6 @@
                         {
                             var routedataremoveall = new Dictionary<string, string> {
                                 {"id", Model.Id.ToString() },
-                                {"titleeng", Model.TitleEng },
-                                {"titlefre", Model.TitleFre },
-                                {"descriptioneng", Model.DescriptionEng },
-                                {"descriptionfre", Model.DescriptionFre },
                                 {"levelcode", Model.LevelCode },
                                 {"levelvalue", Model.LevelValue },
                                 {"regionids", Model.RegionIds },
@@ -414,7 +408,7 @@
                                         <select class="form-control dropdown-toggle mrgn-bttm-md" id="certificate" name="certificate">
                                             @foreach (var certificate in remainingCertificatesToAdd)
                                             {
-                                                <option value="@certificate.Id">@certificate.NameEng / @certificate.NameFre</option>
+                                                <option value="@certificate.Id">@certificate.NameEng <b>/</b> @certificate.NameFre</option>
                                             }
                                         </select>
                                     </div>
@@ -432,7 +426,7 @@
                                                 }
                                                 else
                                                 {
-                                                    <option value="@certificate.Id">@certificate.DescEng / @certificate.DescFre</option>
+                                                    <option value="@certificate.Id">@certificate.DescEng <b>/</b> @certificate.DescFre</option>
                                                 }
                                             }
                                         </select>
@@ -440,7 +434,7 @@
                                 </div>
                                 <div class="modal-footer">
                                     <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>
-                                    <button class="btn btn-primary resetWindowHeight" asp-page-handler="certificate" asp-all-route-data="@routedata">Save Changes</button>
+                                    <button class="btn btn-primary resetWindowHeight" asp-page-handler="certificate" asp-all-route-data="@routedata">Add Certificate</button>
                                 </div>
                             </div>
                         </div>
@@ -458,17 +452,87 @@
                         <div class="row">
                             <div class="col-9">
                                 <div class="accordion" id="@divKey">
-                                    <button class="btn btn-link collapsed text-wrap text-left" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="collapseOne">
-                                        @certificate.NameEng / @certificate.NameFre
+                                    <button class="btn btn-link collapsed text-wrap text-left" type="button" data-toggle="collapse" data-target="#@key1" aria-expanded="false" aria-controls="collapseOne" id="certificateScroll-@certificate.Id">
+                                        @certificate.NameEng <b>/</b> @certificate.NameFre
                                     </button>
                                     <div id="@key1" class="collapse" aria-labelledby="#certTableHeader" data-parent="#@divKey">
                                         <div class="card-body">
 
                                             @{
+                                                bool emptyCertificateDesc = certificate.CertificateDescEng == "" || certificate.CertificateDescFre == "";
                                                 bool emptySelectedCertDesc = (certificate.DescEng == "" && certificate.DescFre == "");
                                             }
-                                            <select class="form-control dropdown-toggle mrgn-bttm-md cert-desc-dropdown 
-                                                @(emptySelectedCertDesc ? "bold" : "")" id="cert-desc-@certificate.Id">
+
+                                            @if (!emptyCertificateDesc)
+                                            {
+                                                <button type="button" class="btn btn-link collapsed no-padding small-margin-bottom display-block" data-toggle="collapse" data-target="#CertificateDescription-@certificate.Id">
+                                                    Certificate Descritpion
+                                                </button>
+
+                                                <div id="CertificateDescription-@certificate.Id" class="collapse">
+                                                    <div class="card-body no-padding-top xs-margin-bottom">
+                                                        @{
+                                                            string[] languages = { "English", "French" };
+                                                            string[] descriptions = { certificate.CertificateDescEng, certificate.CertificateDescFre };
+
+                                                            for (int i = 0; i < descriptions.Length; i++)
+                                                            {
+                                                                <p class="bold @(i > 0 ? "small-margin-top" : "")">
+                                                                    @languages[i]
+                                                                </p>
+
+                                                                <div>
+                                                                @{
+                                                                    var descPortions = descriptions[i].Split("\r\n");
+                                                                    bool oneLinkAdded = false;
+                                                                    foreach (var desc in descPortions)
+                                                                    {
+                                                                        bool containsALink = false;
+                                                                        if (desc.Contains("http"))
+                                                                        {
+                                                                            containsALink = true;
+                                                                        }
+                                                                        if (!containsALink)
+                                                                        {
+                                                                            <span>@desc</span>
+                                                                            <br />
+                                                                        }
+                                                                        else
+                                                                        {
+                                                                            var formattedLink = Formatter.FormatCertificateDescriptionLink(desc);
+                                                                            var href = formattedLink[0];
+                                                                            var displayStr = formattedLink[1];
+                                                                            
+                                                                            if (oneLinkAdded)
+                                                                            {
+                                                                                <span class="inline-block margin-left-link-spacing">| </span>
+                                                                            }
+
+                                                                            <a href="@href" target="_blank">
+                                                                                @displayStr
+                                                                                <img src="~/images/icons/external_link_icon.png" 
+                                                                                class="external-link" alt="Open link in new tab" />
+                                                                            </a>
+
+                                                                            if (!oneLinkAdded)
+                                                                            {
+                                                                                oneLinkAdded = true;
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                                </div>
+                                                            }
+                                                        }
+                                                    </div>
+                                                </div>
+                                            }
+
+                                            <label for="selectedCertDesc-@certificate.Id" class="xs-margin-bottom">Selected Description:</label>
+                                            <br />
+
+                                            <select class="form-control dropdown-toggle mrgn-bttm-md cert-desc-dropdown small-padding-top
+                                                @(emptySelectedCertDesc ? "bold" : "")" id="selectedCertDesc-@certificate.Id">
                                                 @foreach (var desc in certDescs)
                                                 {
                                                     bool emptyDescInDropdown = (desc.DescEng == "" && desc.DescFre == "");
@@ -495,7 +559,7 @@
                                                 <a class="cert-desc-link @(emptySelectedCertDesc ? "dontShow" : "")" 
                                                     href="/Certificates/Descriptions/Edit?id=@certificate.CertificateDescId" 
                                                     target="@(expandableItemsOpenNewWindows ? "_blank" : "_self")">
-                                                    Edit Certificate Description
+                                                    Edit Selected Certificate Description
                                                         <img src="~/images/icons/external_link_icon.png" 
                                                         class="external-link" alt="Open link in new tab" />
                                                 </a>
@@ -511,10 +575,6 @@
                                 @{
                                     var routedataremove = new Dictionary<string, string> {
                                         {"id", Model.Id.ToString() },
-                                        {"titleeng", Model.TitleEng },
-                                        {"titlefre", Model.TitleFre },
-                                        {"descriptioneng", Model.DescriptionEng },
-                                        {"descriptionfre", Model.DescriptionFre },
                                         {"levelcode", Model.LevelCode },
                                         {"levelvalue", Model.LevelValue },
                                         {"regionids", Model.RegionIds },
@@ -550,6 +610,9 @@
     </tbody>
 </table>
 
+<span asp-validation-for="AddedBehaviouralCompetencyIds" style="padding-bottom: 6px" 
+class="text-danger display-block small-margin-bottom no-padding-top bold"></span>
+
 <div class="dontShow">
     @{
         var levels = await Model.GetCompetencyLevelDescriptions();
@@ -565,10 +628,10 @@
             {
                 freStr += " " + level.DescFre;
             }
-            <div class="competencyLevelDesc">
-                <span class="eng">@engStr</span>
-                <span class="fre">@freStr</span>
-            </div>
+                <div class="competencyLevelDesc">
+                    <span class="eng">@engStr</span>
+                    <span class="fre">@freStr</span>
+                </div>
         }
     }
 </div>

--- a/Admin/Pages/Shared/_SimilarEdit.cshtml
+++ b/Admin/Pages/Shared/_SimilarEdit.cshtml
@@ -202,6 +202,9 @@
             <input type="hidden" data-val="true" data-val-required="The Position field is required." 
                 id="JobPosition_Position" name="JobPosition.Position" value="@Model.JobPositionId" />
 
+
+            <input type="hidden" name="PercentSelection" value="@Model.PercentMatch.ToString()" />
+
             <table class="table table-bordered">
                 <thead>
                     <tr>
@@ -541,7 +544,7 @@
 
                                     <div class="row">
                                         <div class="col-10 @(position.JobTitleId == Model.JobPositionId ? "same-position" : "")">
-                                            <a target="_blank" class="btn btn-link text-left text-wrap" href="/Positions/Details?positionid=@position.JobTitleId">
+                                            <a target="_blank" class="btn btn-link text-left text-wrap" href="/Positions/Details?positionid=@position.JobTitleId" id="positionScroll-@position.JobTitleId">
                                                 @position.JobGroupLevelCode @position.JobTitleEng 
                                                 <span class="bold @(position.JobTitleId == Model.JobPositionId ? "text-dark" : "")">/</span> 
                                                 @position.JobTitleFre 

--- a/Admin/Pages/Similar/Create.cshtml
+++ b/Admin/Pages/Similar/Create.cshtml
@@ -14,7 +14,6 @@
         {"AddedNinetyPercentIds", Model.AddedNinetyPercentIds },
         {"AddedEightyPercentIds", Model.AddedEightyPercentIds },
         {"AddedSeventyPercentIds", Model.AddedSeventyPercentIds },
-        {"selectedjobpositionid",Model.SelectedJobPositionId.ToString() },
         {"subgroupcode", Model.SubGroupCode },
         {"subjobgroupId" , Model.SubJobGroupId.ToString() },
         {"jobgrouplevelid", Model.JobGroupLevelId.ToString() },
@@ -40,7 +39,6 @@
         JobGroupLevelPositions = Model.JobGroupLevelPositions,
         AllActiveJobs = await Model.GetAllActiveJobs(),
         CurrentSelectedLevelCode = Model.LevelCode,
-        CurrentSelectedPosition = Model.CurrentSelectedPosition,
         CreateModel = Model,
         IsInEditMode = false,
         CopyingAPosition = Model.CopyingAPosition
@@ -72,6 +70,8 @@ else
 }
 
 <hr />
+
+<span asp-validation-for="PercentSelection" class="text-danger bold display-block small-margin-bottom"></span>
 
 @if (Model.PercentSelection == "100")
 {

--- a/Admin/Pages/Similar/Create.cshtml.cs
+++ b/Admin/Pages/Similar/Create.cshtml.cs
@@ -19,7 +19,6 @@ namespace Admin.Pages.Similar
         private readonly ILogger<CreateModel> _logger;
         private readonly JobPositionService _jobPositionService;
 
-
         public CreateModel(DataModel.CctDbContext context,
             ILogger<CreateModel> logger, JobPositionService jobPositionService)
         {
@@ -34,14 +33,11 @@ namespace Admin.Pages.Similar
         [BindProperty]
         public JobGroupDto[] JobGroups { get; set; }
         public JobGroupDto CurrentSelectedJobGroup { get; set; }
-        public JobGroupPositionDto CurrentSelectedLevelCode { get; set; }
         public JobPositionDto CurrentPosition { get; set; }
-        public JobPositionDto CurrentSelectedPosition { get; set; }
-        public string CurrentSelectedJobTitleEng { get; set; } = string.Empty;
-        public string CurrentSelectedJobTitleFre { get; set; } = string.Empty;
-        public JobGroupPositionDto[] JobGroupPositions { get; set; }
         [BindProperty(SupportsGet = true)]
         public int SelectedJobPositionId { get; set; }
+        public JobGroupPositionDto[] JobGroupPositions { get; set; }
+        [BindProperty(SupportsGet = true)]
         public JobPositionDto[] JobGroupLevelPositions { get; set; } = new JobPositionDto[] { };
         [BindProperty(SupportsGet = true)]
         public int JobGroupId { get; set; } = 2;
@@ -75,15 +71,132 @@ namespace Admin.Pages.Similar
 
         public JobPositionDto PositionBeingCopied { get; set; }
 
+        private Dictionary<int, bool> _allJobPositionIds = new Dictionary<int, bool>();
+
         public async Task<List<JobPositionDto>> GetAllActiveJobs()
         {
             var jobs = await _jobPositionService.GetAllJobPositions();
             return jobs.Where(x => x.Active == 1).ToList();
         }
 
+        private async Task PrepareAllJobsDictionary()
+        {
+            var jobs = await _jobPositionService.GetAllJobPositions();
+
+            foreach (var job in jobs)
+            {
+                _allJobPositionIds.Add(job.JobTitleId, job.Active == 1);
+            }
+        }
+
         public async Task<JobGroupPositionDto[]> GetJobGroupPositionLevelsById(int id)
         {
             return await _jobPositionService.GetJobGroupPositionLevelsById(id);
+        }
+
+        private string PrepareQueryString(string ids, int deletedposid)
+        {
+            var separatedIds = ids.Split('-').Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var result = string.Empty;
+
+            foreach (var id in separatedIds)
+            {
+                bool success = int.TryParse(id, out int numberid);
+                if (success && numberid != deletedposid)
+                {
+                    if (_allJobPositionIds.TryGetValue(numberid, out bool boolVar))
+                    {
+                        result += "&PositionId=" + numberid.ToString();
+                    }
+                }
+            }
+            return result;
+        }
+
+        private async Task PrepareJobGroupPositions(int jobgroupid)
+        {
+            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
+        }
+
+        private async Task PreparePageModel(int percent, int jobgroupid, string levelvalue, string subgroupcode, int deletedposid = 0)
+        {
+            int[] acceptedPercents = { 100, 90, 80, 70 };
+            if (!acceptedPercents.Contains(percent))
+            {
+                percent = 100;
+            }
+
+            await PrepareAllJobsDictionary();
+
+            PercentSelection = percent.ToString();
+            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
+            JobGroups = await _jobPositionService.GetJobGroups();
+            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
+            if (string.IsNullOrWhiteSpace(levelvalue))
+            {
+                JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
+                LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
+            }
+            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
+            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
+
+            if (percent == 100)
+            {
+                var querystring = PrepareQueryString(AddedOneHundredPercentIds, deletedposid);
+                AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+            else if (percent == 90)
+            {
+                var querystring = PrepareQueryString(AddedNinetyPercentIds, deletedposid);
+                AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+            else if (percent == 80)
+            {
+                var querystring = PrepareQueryString(AddedEightyPercentIds, deletedposid);
+                AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+            else if (percent == 70)
+            {
+                var querystring = PrepareQueryString(AddedSeventyPercentIds, deletedposid);
+                AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+
+            if (deletedposid != 0)
+            {
+                if (percent == 100)
+                {
+                    AddedOneHundredPercentIds = string.Empty;
+                    foreach (var position in AddedOneHundredPercentJobPositions)
+                    {
+                        AddedOneHundredPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+                else if (percent == 90)
+                {
+                    AddedNinetyPercentIds = string.Empty;
+                    foreach (var position in AddedNinetyPercentJobPositions)
+                    {
+                        AddedNinetyPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+                else if (percent == 80)
+                {
+                    AddedEightyPercentIds = string.Empty;
+                    foreach (var position in AddedEightyPercentJobPositions)
+                    {
+                        AddedEightyPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+                else if (percent == 70)
+                {
+                    AddedSeventyPercentIds = string.Empty;
+                    foreach (var position in AddedSeventyPercentJobPositions)
+                    {
+                        AddedSeventyPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+            }
+
         }
 
         public async Task<IActionResult> OnGetAsync(int? id, int? copyid)
@@ -146,7 +259,7 @@ namespace Admin.Pages.Similar
             {
                 JobPosition = await _context.SearchSimilarJobs.FirstOrDefaultAsync(m => m.Position == id);
 
-                if (JobPosition != null) // if the position already has some similar jobs, you should see the edit page
+                if (JobPosition != null) // if the position already has some similar jobs, users should see the edit page
                 {
                     return Redirect("/Similar/Edit?id=" + CurrentPosition.JobTitleId);
                 }
@@ -162,131 +275,90 @@ namespace Admin.Pages.Similar
             LevelCode = CurrentPosition.LevelCode;
             SubGroupCode = JobGroupPositions.FirstOrDefault().SubGroupCode;
             LevelValue = JobGroupPositions.FirstOrDefault().LevelValue;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
 
             if (CopyingAPosition)
             {
+                await PrepareAllJobsDictionary();
                 AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(copiedPositionSimilar.HundredPercent);
-                foreach (var added in copiedPositionSimilar.HundredPercent.Split("&PositionId=").Distinct())
+
+                string[] addedPositionIds = { copiedPositionSimilar.HundredPercent, copiedPositionSimilar.NinetyPercent,
+                    copiedPositionSimilar.EightyPercent, copiedPositionSimilar.SeventyPercent };
+                string[] addedIdsToCopy = new string[4];
+
+                for (int i = 0; i < addedPositionIds.Length; i++)
                 {
-                    if (!string.IsNullOrEmpty(added))
+                    var ids = addedPositionIds[i].Split("&PositionId=").Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+                    addedIdsToCopy[i] = string.Empty;
+
+                    foreach (var added in ids)
                     {
-                        int number;
-                        bool success = int.TryParse(added, out number);
+                        bool success = int.TryParse(added, out int number);
                         if (success)
                         {
-                            AddedOneHundredPercentIds += number.ToString() + '-';
+                            if (_allJobPositionIds.TryGetValue(number, out bool boolVar))
+                            {
+                                addedIdsToCopy[i] += number.ToString() + '-';
+                            } 
                         }
                     }
                 }
-                foreach (var added in copiedPositionSimilar.NinetyPercent.Split("&PositionId=").Distinct())
-                {
-                    if (!string.IsNullOrEmpty(added))
-                    {
-                        int number;
-                        bool success = int.TryParse(added, out number);
-                        if (success)
-                        {
-                            AddedNinetyPercentIds += number.ToString() + '-';
-                        }
-                    }
-                }
-                foreach (var added in copiedPositionSimilar.EightyPercent.Split("&PositionId=").Distinct())
-                {
-                    if (!string.IsNullOrEmpty(added))
-                    {
-                        int number;
-                        bool success = int.TryParse(added, out number);
-                        if (success)
-                        {
-                            AddedEightyPercentIds += number.ToString() + '-';
-                        }
-                    }
-                }
-                foreach (var added in copiedPositionSimilar.SeventyPercent.Split("&PositionId=").Distinct())
-                {
-                    if (!string.IsNullOrEmpty(added))
-                    {
-                        int number;
-                        bool success = int.TryParse(added, out number);
-                        if (success)
-                        {
-                            AddedSeventyPercentIds += number.ToString() + '-';
-                        }
-                    }
-                }
+
+                AddedOneHundredPercentIds = addedIdsToCopy[0];
+                AddedNinetyPercentIds = addedIdsToCopy[1];
+                AddedEightyPercentIds = addedIdsToCopy[2];
+                AddedSeventyPercentIds = addedIdsToCopy[3];
             }
 
             return Page();
         }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostEdit()
         {
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(int.Parse(PercentSelection), JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
+
+            bool onePositionAdded = ((!string.IsNullOrWhiteSpace(AddedOneHundredPercentIds)) || 
+                (!string.IsNullOrWhiteSpace(AddedNinetyPercentIds)) || 
+                (!string.IsNullOrWhiteSpace(AddedEightyPercentIds)) || 
+                (!string.IsNullOrWhiteSpace(AddedSeventyPercentIds)));
+
+            if (!onePositionAdded)
+            {
+                ModelState.AddModelError("PercentSelection", "Make sure that at least one similar position has been added");
+            }
+
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
-            var querystring100 = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-').Distinct())
+            string[] addedPositionIds = { AddedOneHundredPercentIds, AddedNinetyPercentIds, AddedEightyPercentIds, AddedSeventyPercentIds };
+            string[] queryStrings = new string[4];
+
+            for (int i = 0; i < addedPositionIds.Length; i++)
             {
-                if (!string.IsNullOrEmpty(id))
+                var ids = addedPositionIds[i].Split('-').Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+                queryStrings[i] = string.Empty;
+
+                foreach (var id in ids)
                 {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
+                    bool success = int.TryParse(id, out int numberid);
                     if (success)
                     {
-                        querystring100 += "&PositionId=" + numberid.ToString();
+                        if (_allJobPositionIds.TryGetValue(numberid, out bool boolVar))
+                        {
+                            queryStrings[i] += "&PositionId=" + numberid.ToString();
+                        }
                     }
                 }
             }
-            var querystring90 = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring90 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            var querystring80 = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring80 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            var querystring70 = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring70 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
+
+            var querystring100 = queryStrings[0];
+            var querystring90 = queryStrings[1];
+            var querystring80 = queryStrings[2];
+            var querystring70 = queryStrings[3];
 
             bool creatingSimilarPositions = true;
 
@@ -300,19 +372,14 @@ namespace Admin.Pages.Similar
 
             if (creatingSimilarPositions)
             {
-
-                try
+                await _jobPositionService.PostSimilarPositions(new SearchSimilarJob()
                 {
-                    await _jobPositionService.PostSimilarPositions(new SearchSimilarJob()
-                    {
-                        Position = Id,
-                        HundredPercent = querystring100,
-                        NinetyPercent = querystring90,
-                        EightyPercent = querystring80,
-                        SeventyPercent = querystring70,
-                    });
-                }
-                catch { }
+                    Position = Id,
+                    HundredPercent = querystring100,
+                    NinetyPercent = querystring90,
+                    EightyPercent = querystring80,
+                    SeventyPercent = querystring70,
+                });
             }
             else
             {
@@ -321,660 +388,139 @@ namespace Admin.Pages.Similar
                 JobPosition.EightyPercent = querystring80;
                 JobPosition.SeventyPercent = querystring70;
 
-                try
-                {
-                    await _jobPositionService.UpdateSimilarPositions(JobPosition);
-                }
-                catch { }
+                await _jobPositionService.UpdateSimilarPositions(JobPosition);
             }
 
             return RedirectToPage("Details", new { Id });
         }
+
         public async Task OnPostGroupOneHundredPercent()
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelOneHundredPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(100, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostGroupNinetyPercent()
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelNinetyPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(90, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostGroupEightyPercent()
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelEightyPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(80, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostGroupSeventyPercent()
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelSeventyPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(70, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostSelectOneHundredPercent()
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostSelectNinetyPercent()
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostSelectEightyPercent()
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostSelectSeventyPercent()
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostAddOneHundredPercentSimilarPosition()
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedOneHundredPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteOneHundredPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentIds = string.Empty;
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedOneHundredPercentJobPositions)
-            {
-                AddedOneHundredPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
+
         public async Task OnPostAddNinetyPercentSimilarPosition()
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedNinetyPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteNinetyPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentIds = string.Empty;
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedNinetyPercentJobPositions)
-            {
-                AddedNinetyPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
+
         public async Task OnPostAddEightyPercentSimilarPosition()
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedEightyPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteEightyPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentIds = string.Empty;
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedEightyPercentJobPositions)
-            {
-                AddedEightyPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
+
         public async Task OnPostAddSeventyPercentSimilarPosition()
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedSeventyPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteSeventyPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentIds = string.Empty;
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedSeventyPercentJobPositions)
-            {
-                AddedSeventyPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
-        private bool JobPositionExists(int id)
-        {
-            return _context.JobPositions.Any(e => e.Id == id);
-        }
+
     }
 }

--- a/Admin/Pages/Similar/Edit.cshtml
+++ b/Admin/Pages/Similar/Edit.cshtml
@@ -13,7 +13,6 @@
         {"AddedNinetyPercentIds", Model.AddedNinetyPercentIds },
         {"AddedEightyPercentIds", Model.AddedEightyPercentIds },
         {"AddedSeventyPercentIds", Model.AddedSeventyPercentIds },
-        {"selectedjobpositionid",Model.SelectedJobPositionId.ToString() },
         {"subgroupcode", Model.SubGroupCode },
         {"subjobgroupId" , Model.SubJobGroupId.ToString() },
         {"jobgrouplevelid", Model.JobGroupLevelId.ToString() }
@@ -38,7 +37,6 @@
         JobGroupLevelPositions = Model.JobGroupLevelPositions,
         AllActiveJobs = await Model.GetAllActiveJobs(),
         CurrentSelectedLevelCode = Model.LevelCode,
-        CurrentSelectedPosition = Model.CurrentSelectedPosition,
         EditModel = Model,
         HadSimilarPositionsOnLoadingPage = await Model.HasSimilarPositionsOnLoadingPage(Model.Id)
     };
@@ -54,6 +52,8 @@
     <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" /></a></h4>
 
 <hr />
+
+<span asp-validation-for="PercentSelection" class="text-danger bold display-block small-margin-bottom"></span>
 
 @if (Model.PercentSelection == "100")
 {

--- a/Admin/Pages/Similar/Edit.cshtml.cs
+++ b/Admin/Pages/Similar/Edit.cshtml.cs
@@ -35,11 +35,8 @@ namespace Admin.Pages.Similar
         [BindProperty]
         public JobGroupDto[] JobGroups { get; set; }
         public JobGroupDto CurrentSelectedJobGroup { get; set; }
-        public JobGroupPositionDto CurrentSelectedLevelCode { get; set; }
         public JobPositionDto CurrentPosition { get; set; }
         public JobPositionDto CurrentSelectedPosition { get; set; }
-        public string CurrentSelectedJobTitleEng { get; set; } = string.Empty;
-        public string CurrentSelectedJobTitleFre { get; set; } = string.Empty;
         public JobGroupPositionDto[] JobGroupPositions { get; set; }
         [BindProperty(SupportsGet = true)]
         public int SelectedJobPositionId { get; set; }
@@ -70,6 +67,8 @@ namespace Admin.Pages.Similar
         public JobPositionDto[] AddedSeventyPercentJobPositions = new JobPositionDto[] { };
         [BindProperty(SupportsGet = true)]
         public string AddedSeventyPercentIds { get; set; } = string.Empty;
+
+        private Dictionary<int, bool> _allJobPositionIds = new Dictionary<int, bool>();
 
         public async Task<List<JobPositionDto>> GetAllActiveJobs()
         {
@@ -106,6 +105,121 @@ namespace Admin.Pages.Similar
                 }
             }
             return false;
+        }
+
+        private async Task PrepareAllJobsDictionary()
+        {
+            var jobs = await _jobPositionService.GetAllJobPositions();
+
+            foreach (var job in jobs)
+            {
+                _allJobPositionIds.Add(job.JobTitleId, job.Active == 1);
+            }
+        }
+
+        private string PrepareQueryString(string ids, int deletedposid)
+        {
+            var separatedIds = ids.Split('-').Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+            var result = string.Empty;
+
+            foreach (var id in separatedIds)
+            {
+                bool success = int.TryParse(id, out int numberid);
+                if (success && numberid != deletedposid)
+                {
+                    if (_allJobPositionIds.TryGetValue(numberid, out bool boolVar))
+                    {
+                        result += "&PositionId=" + numberid.ToString();
+                    }
+                }
+            }
+            return result;
+        }
+
+        private async Task PrepareJobGroupPositions(int jobgroupid)
+        {
+            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
+        }
+
+        private async Task PreparePageModel(int percent, int jobgroupid, string levelvalue, string subgroupcode, int deletedposid = 0)
+        {
+            int[] acceptedPercents = { 100, 90, 80, 70 };
+            if (!acceptedPercents.Contains(percent))
+            {
+                percent = 100;
+            }
+
+            await PrepareAllJobsDictionary();
+
+            PercentSelection = percent.ToString();
+            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
+            JobGroups = await _jobPositionService.GetJobGroups();
+            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
+            if (string.IsNullOrWhiteSpace(levelvalue))
+            {
+                JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
+                LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
+            }
+            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
+            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
+
+            if (percent == 100)
+            {
+                var querystring = PrepareQueryString(AddedOneHundredPercentIds, deletedposid);
+                AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+            else if (percent == 90)
+            {
+                var querystring = PrepareQueryString(AddedNinetyPercentIds, deletedposid);
+                AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+            else if (percent == 80)
+            {
+                var querystring = PrepareQueryString(AddedEightyPercentIds, deletedposid);
+                AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+            else if (percent == 70)
+            {
+                var querystring = PrepareQueryString(AddedSeventyPercentIds, deletedposid);
+                AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            }
+
+            if (deletedposid != 0)
+            {
+                if (percent == 100)
+                {
+                    AddedOneHundredPercentIds = string.Empty;
+                    foreach (var position in AddedOneHundredPercentJobPositions)
+                    {
+                        AddedOneHundredPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+                else if (percent == 90)
+                {
+                    AddedNinetyPercentIds = string.Empty;
+                    foreach (var position in AddedNinetyPercentJobPositions)
+                    {
+                        AddedNinetyPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+                else if (percent == 80)
+                {
+                    AddedEightyPercentIds = string.Empty;
+                    foreach (var position in AddedEightyPercentJobPositions)
+                    {
+                        AddedEightyPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+                else if (percent == 70)
+                {
+                    AddedSeventyPercentIds = string.Empty;
+                    foreach (var position in AddedSeventyPercentJobPositions)
+                    {
+                        AddedSeventyPercentIds += position.JobTitleId.ToString() + '-';
+                    }
+                }
+            }
+
         }
 
         public async Task<IActionResult> OnGetAsync(int? id, int? percent, int? groupId, string? level)
@@ -167,13 +281,6 @@ namespace Admin.Pages.Similar
             LevelCode = CurrentPosition.LevelCode;
             SubGroupCode = JobGroupPositions.FirstOrDefault().SubGroupCode;
             LevelValue = JobGroupPositions.FirstOrDefault().LevelValue;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
 
             if (groupId != null)
             {
@@ -204,776 +311,219 @@ namespace Admin.Pages.Similar
             AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(JobPosition.NinetyPercent);
             AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(JobPosition.EightyPercent);
             AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(JobPosition.SeventyPercent);
-            foreach (var added in JobPosition.HundredPercent.Split("&PositionId=").Distinct())
+
+            await PrepareAllJobsDictionary();
+
+            string[] addedPositionIds = { JobPosition.HundredPercent, JobPosition.NinetyPercent,
+                    JobPosition.EightyPercent, JobPosition.SeventyPercent };
+            string[] addedIdsToCopy = new string[4];
+
+            for (int i = 0; i < addedPositionIds.Length; i++)
             {
-                if (!string.IsNullOrEmpty(added))
+                var ids = addedPositionIds[i].Split("&PositionId=").Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+                addedIdsToCopy[i] = string.Empty;
+
+                foreach (var added in ids)
                 {
-                    int number;
-                    bool success = int.TryParse(added, out number);
+                    bool success = int.TryParse(added, out int number);
                     if (success)
                     {
-                        AddedOneHundredPercentIds += number.ToString() + '-';
+                        if (_allJobPositionIds.TryGetValue(number, out bool boolVar))
+                        {
+                            addedIdsToCopy[i] += number.ToString() + '-';
+                        }
                     }
                 }
             }
-            foreach (var added in JobPosition.NinetyPercent.Split("&PositionId=").Distinct())
-            {
-                if (!string.IsNullOrEmpty(added))
-                {
-                    int number;
-                    bool success = int.TryParse(added, out number);
-                    if (success)
-                    {
-                        AddedNinetyPercentIds += number.ToString() + '-';
-                    }
-                }
-            }
-            foreach (var added in JobPosition.EightyPercent.Split("&PositionId=").Distinct())
-            {
-                if (!string.IsNullOrEmpty(added))
-                {
-                    int number;
-                    bool success = int.TryParse(added, out number);
-                    if (success)
-                    {
-                        AddedEightyPercentIds += number.ToString() + '-';
-                    }
-                }
-            }
-            foreach (var added in JobPosition.SeventyPercent.Split("&PositionId=").Distinct())
-            {
-                if (!string.IsNullOrEmpty(added))
-                {
-                    int number;
-                    bool success = int.TryParse(added, out number);
-                    if (success)
-                    {
-                        AddedSeventyPercentIds += number.ToString() + '-';
-                    }
-                }
-            }
+
+            AddedOneHundredPercentIds = addedIdsToCopy[0];
+            AddedNinetyPercentIds = addedIdsToCopy[1];
+            AddedEightyPercentIds = addedIdsToCopy[2];
+            AddedSeventyPercentIds = addedIdsToCopy[3];
+
             return Page();
         }
 
-        // To protect from overposting attacks, enable the specific properties you want to bind to, for
-        // more details, see https://aka.ms/RazorPagesCRUD.
         public async Task<IActionResult> OnPostEdit()
         {
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(int.Parse(PercentSelection), JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
+
+            bool onePositionAdded = ((!string.IsNullOrWhiteSpace(AddedOneHundredPercentIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedNinetyPercentIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedEightyPercentIds)) ||
+                (!string.IsNullOrWhiteSpace(AddedSeventyPercentIds)));
+
+            if (!onePositionAdded)
+            {
+                ModelState.AddModelError("PercentSelection", "Make sure that at least one similar position has been added");
+            }
+
             if (!ModelState.IsValid)
             {
                 return Page();
             }
 
-            var querystring100 = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring100 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            var querystring90 = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring90 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            var querystring80 = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring80 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            var querystring70 = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-').Distinct())
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring70 += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            JobPosition.HundredPercent = querystring100;
-            JobPosition.NinetyPercent = querystring90;
-            JobPosition.EightyPercent = querystring80;
-            JobPosition.SeventyPercent = querystring70;
+            string[] addedPositionIds = { AddedOneHundredPercentIds, AddedNinetyPercentIds, AddedEightyPercentIds, AddedSeventyPercentIds };
+            string[] queryStrings = new string[4];
 
-            try
+            for (int i = 0; i < addedPositionIds.Length; i++)
             {
-                await _jobPositionService.UpdateSimilarPositions(JobPosition);
+                var ids = addedPositionIds[i].Split('-').Distinct().Where(x => !string.IsNullOrEmpty(x)).ToList();
+
+                queryStrings[i] = string.Empty;
+
+                foreach (var id in ids)
+                {
+                    bool success = int.TryParse(id, out int numberid);
+                    if (success)
+                    {
+                        if (_allJobPositionIds.TryGetValue(numberid, out bool boolVar))
+                        {
+                            queryStrings[i] += "&PositionId=" + numberid.ToString();
+                        }
+                    }
+                }
             }
-            catch { }
+
+            JobPosition.HundredPercent = queryStrings[0];
+            JobPosition.NinetyPercent = queryStrings[1];
+            JobPosition.EightyPercent = queryStrings[2];
+            JobPosition.SeventyPercent = queryStrings[3];
+
+            await _jobPositionService.UpdateSimilarPositions(JobPosition);
 
             return RedirectToPage("Details", new { Id });
         }
+
         public async Task OnPostGroupOneHundredPercent()
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelOneHundredPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(100, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostGroupNinetyPercent()
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelNinetyPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(90, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostGroupEightyPercent()
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelEightyPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(80, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostGroupSeventyPercent()
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(JobGroupPositions.FirstOrDefault().SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupPositions.FirstOrDefault().JobGroupId, JobGroupPositions.FirstOrDefault().SubGroupCode, JobGroupPositions.FirstOrDefault().LevelValue);
-            SubJobGroupId = JobGroupPositions.FirstOrDefault().SubJobGroupId;
-            JobGroupLevelId = JobGroupPositions.FirstOrDefault().LevelId;
-            LevelCode = JobGroupPositions.FirstOrDefault().LevelCode;
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostLevelSeventyPercent(int jobgroupid, string levelvalue, string subgroupcode)
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(jobgroupid);
             JobGroupLevelPositions = string.IsNullOrEmpty(subgroupcode) ? await _jobPositionService.GetJobGroupPositionsByLevel(jobgroupid, levelvalue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(jobgroupid, subgroupcode, levelvalue);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(jobgroupid);
-            CurrentSelectedPosition = JobGroupLevelPositions.Where(e => e.Active != 0).FirstOrDefault();
-            if (CurrentSelectedPosition != null)
-            {
-                CurrentSelectedJobTitleEng = CurrentSelectedPosition?.JobTitleEng;
-                CurrentSelectedJobTitleFre = CurrentSelectedPosition?.JobTitleFre;
-                SelectedJobPositionId = CurrentSelectedPosition.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(jobgroupid);
+            await PreparePageModel(70, jobgroupid, levelvalue, subgroupcode);
         }
+
         public async Task OnPostSelectOneHundredPercent()
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostSelectNinetyPercent()
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostSelectEightyPercent()
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostSelectSeventyPercent()
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
 
         public async Task OnPostAddOneHundredPercentSimilarPosition()
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedOneHundredPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteOneHundredPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "100";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedOneHundredPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedOneHundredPercentIds = string.Empty;
-            AddedOneHundredPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedOneHundredPercentJobPositions)
-            {
-                AddedOneHundredPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(100, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
+
         public async Task OnPostAddNinetyPercentSimilarPosition()
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(CurrentPosition.JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedNinetyPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteNinetyPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "90";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedNinetyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedNinetyPercentIds = string.Empty;
-            AddedNinetyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedNinetyPercentJobPositions)
-            {
-                AddedNinetyPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(90, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
+
         public async Task OnPostAddEightyPercentSimilarPosition()
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedEightyPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteEightyPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "80";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedEightyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedEightyPercentIds = string.Empty;
-            AddedEightyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedEightyPercentJobPositions)
-            {
-                AddedEightyPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(80, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
+
         public async Task OnPostAddSeventyPercentSimilarPosition()
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
             AddedSeventyPercentIds += SelectedJobPositionId.ToString() + '-';
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode);
         }
+
         public async Task OnPostDeleteSeventyPercentSimilarPosition(int deletepositionid)
         {
-            PercentSelection = "70";
-            CurrentPosition = await _jobPositionService.GetJobPositionById(Id);
-            if (SelectedJobPositionId != 0)
-            {
-                var positiondto = await _jobPositionService.GetJobPositionById(SelectedJobPositionId);
-                CurrentSelectedJobTitleEng = positiondto.JobTitleEng;
-                CurrentSelectedJobTitleFre = positiondto.JobTitleFre;
-                SelectedJobPositionId = positiondto.JobTitleId;
-            }
-            var querystring = string.Empty;
-            foreach (var id in AddedSeventyPercentIds.Split('-'))
-            {
-                if (!string.IsNullOrEmpty(id))
-                {
-                    int numberid;
-                    bool success = int.TryParse(id, out numberid);
-                    if (success && numberid != deletepositionid)
-                    {
-                        querystring += "&PositionId=" + numberid.ToString();
-                    }
-                }
-            }
-            AddedSeventyPercentIds = string.Empty;
-            AddedSeventyPercentJobPositions = await _jobPositionService.GetJobPositionByIdValues(querystring);
-            foreach (var position in AddedSeventyPercentJobPositions)
-            {
-                AddedSeventyPercentIds += position.JobTitleId.ToString() + '-';
-            }
-            JobGroupPositions = await _jobPositionService.GetJobGroupPositionLevelsById(JobGroupId);
-            JobGroups = await _jobPositionService.GetJobGroups();
-            CurrentSelectedJobGroup = await _jobPositionService.GetJobGroupById(JobGroupId);
-            JobGroupLevelPositions = string.IsNullOrEmpty(SubGroupCode) ? await _jobPositionService.GetJobGroupPositionsByLevel(JobGroupId, LevelValue) : await _jobPositionService.GetJobGroupPositionsBySubGroupLevel(JobGroupId, SubGroupCode, LevelValue);
+            await PrepareJobGroupPositions(JobGroupId);
+            await PreparePageModel(70, JobGroupId, JobGroupPositions.FirstOrDefault().LevelValue, JobGroupPositions.FirstOrDefault().SubGroupCode, deletepositionid);
         }
-        private bool JobPositionExists(int id)
-        {
-            return _context.JobPositions.Any(e => e.Id == id);
-        }
+
     }
 }

--- a/Admin/Pages/Similar/Index.cshtml
+++ b/Admin/Pages/Similar/Index.cshtml
@@ -98,7 +98,7 @@
 
 @if (itemsThatMatchFilter.Any())
 {
-    <div id="table-container">
+    <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
         <table class="table">
             <thead>
                 <tr class="table-header-row text-center">

--- a/Admin/Pages/Similar/Index.cshtml
+++ b/Admin/Pages/Similar/Index.cshtml
@@ -24,7 +24,10 @@
     {
         <p>
             <a class="btn btn-dark" target="_blank" asp-page="ExecutiveSummary">View / Print List</a>
-            <a class="btn btn-secondary pull-right bold" asp-page="Locate">Locate Positions</a>
+            <a class="btn btn-secondary pull-right bold index-right-button" 
+                title="See where jobs have been added as similar positions" data-toggle="tooltip" asp-page="Locate">
+                Locate Positions
+            </a>
         </p> 
     }
 
@@ -55,7 +58,7 @@
         <div class="form-actions no-color">
             <h6>
                 <label for="Filter">Find positions:</label>
-                <input type="text" asp-for="@Model.Filter" />
+                <input type="text" asp-for="@Model.Filter" value="@filterValue" />
 
                 @if (Model.CopyingAPosition)
                 {
@@ -75,16 +78,16 @@
                 {
                     @if (Model.DisplayNumberOfJobsForEachMatchingPercentage)
                     {
-                        <a class="pull-right" href="/Similar?numMatching=false&filter=@filterValue">Hide Number of Matching Positions Per Percentage</a>
+                        <a class="pull-right index-right-button" href="/Similar?numMatching=false&filter=@filterValue">Hide Number of Matching Positions Per Percentage</a>
                     }
                     else
                     {
-                        <a class="pull-right" href="/Similar?numMatching=true&filter=@filterValue">View Number of Matching Positions Per Percentage</a>
+                        <a class="pull-right index-right-button" href="/Similar?numMatching=true&filter=@filterValue">View Number of Matching Positions Per Percentage</a>
                     }
                 }
                 else
                 {
-                    <a class="btn btn-danger pull-right bottom-two-px bold" href="/Similar/Details?id=@Model.PositionBeingCopied.JobTitleId">
+                    <a class="btn btn-danger pull-right bottom-two-px bold index-right-button" href="/Similar/Details?id=@Model.PositionBeingCopied.JobTitleId">
                         Cancel Copy
                     </a>
                 }

--- a/Admin/Pages/Similar/Index.cshtml.cs
+++ b/Admin/Pages/Similar/Index.cshtml.cs
@@ -32,6 +32,8 @@ namespace Admin.Pages.Similar
 
         public bool DisplayTopOfPage { get; set; }
 
+        public double LastTableContainerHeight { get; set; } = 300;
+
         public bool DisplayNumberOfJobsForEachMatchingPercentage { get; set; } = false;
 
         private const string PercentageSessionString = "DisplayNumberOfJobsForEachMatchingPercentage";
@@ -82,6 +84,17 @@ namespace Admin.Pages.Similar
                 if (sessionStr.ToLower() == "false")
                 {
                     DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
                 }
             }
 

--- a/Admin/Pages/Similar/Locate.cshtml
+++ b/Admin/Pages/Similar/Locate.cshtml
@@ -13,6 +13,21 @@
                             Model.PositionsThatHaveItAtEightyMatch.Any() ||
                             Model.PositionsThatHaveItAtSeventyMatch.Any());
     }
+
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.JobPositions.Where(e => (Model.Filter == null
+        || e.JobTitleEng.ToLower().Contains(Model.Filter.ToLower())
+        || e.JobTitleFre.ToLower().Contains(Model.Filter.ToLower())
+        || e.LevelCode.ToLower().Contains(Model.Filter.ToLower()))
+        && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
+    var itemsList = itemsThatMatchFilter.ToList();
 }
 
 @functions {
@@ -44,7 +59,7 @@
             <div class="form-actions no-color">
                 <h6>
                     <label for="Filter">Find positions:</label>
-                    <input type="text" asp-for="@Model.Filter" />
+                    <input type="text" asp-for="@Model.Filter" value="@filterValue" />
 
                     <input type="submit" value="Search" class="btn btn-primary" /> 
                     @if (!String.IsNullOrWhiteSpace(Model.Filter))
@@ -63,8 +78,8 @@
     {
         <h4 class="small-margin-bottom">Located Position: 
             <a target="_blank" href="/Positions/Details?positionid=@Model.PositionBengLocated.JobTitleId">
-                <span id="jobTitleEng">@Model.PositionBengLocated.JobGroupLevelCode @Model.PositionBengLocated.JobTitleEng</span>
-                <span id="jobTitleFre" class="dontShow">@Model.PositionBengLocated.JobGroupLevelCode @Model.PositionBengLocated.JobTitleFre</span>
+                <span id="jobTitleEng" class="print-link">@Model.PositionBengLocated.JobGroupLevelCode @Model.PositionBengLocated.JobTitleEng</span>
+                <span id="jobTitleFre" class="dontShow print-link">@Model.PositionBengLocated.JobGroupLevelCode @Model.PositionBengLocated.JobTitleFre</span>
                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
             </a>
         </h4>
@@ -85,30 +100,13 @@
                 <div class="col text-right no-margin-right no-padding @(addedInOnePlace ? "raise-elements-slightly" : "")" style="max-height: 38px">
                     @if (addedInOnePlace)
                     {
-                        <h6 class="glyphicon glyphicon-save-file display-inline position-relative" style="top: 4px !important; right: 5px;" onclick="print()"></h6>
+                        <h6 class="glyphicon glyphicon-save-file display-inline position-relative locate-page-save-icon" onclick="print()"></h6>
                     }
                     <h6 class="display-inline"><a class="btn btn-primary bold bottom-two-px" href="/Similar/Locate">Locate Another Position</a></h6>
                     <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" asp-page="Index">Back to List</a>
                 </div>
             </div>
         </div>
-    }
-
-    @{
-        string? filterValue = Model.Filter;
-        if (filterValue != null)
-        {
-            filterValue = filterValue.Trim();
-        }
-
-        var itemsThatMatchFilter = Model.JobPositions.Where(e => (Model.Filter == null
-            || e.JobTitleEng.ToLower().Contains(Model.Filter.ToLower())
-            || e.JobTitleFre.ToLower().Contains(Model.Filter.ToLower())
-            || e.LevelCode.ToLower().Contains(Model.Filter.ToLower()))
-            && (e.Active == 1));
-
-        itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.JobTitleEng.ToLower()).OrderBy(x => x.LevelCode.ToLower()).ToList();
-        var itemsList = itemsThatMatchFilter.ToList();
     }
 </div>
 
@@ -212,7 +210,7 @@ else
                 <tbody>
 
                     @{
-                        string urlEnd = "&groupId=" + Model.PositionBengLocated.JobGroupId + "&level=" + Model.PositionBengLocated.LevelCode.ToUpper();
+                        string urlEnd = "&groupId=" + Model.PositionBengLocated.JobGroupId + "&level=" + Model.PositionBengLocated.LevelCode.ToUpper() + "&scrollTo=positionScroll-" + Model.PositionBengLocated.JobTitleId + "_c_h";
                     }
 
                     @for (int i = 0; i < numRows; i++)
@@ -256,12 +254,12 @@ else
                                         @if (hundredPos != null)
                                         {
                                             <a href="/Similar/Edit?id=@hundredPos.JobTitleId&percent=100@(urlEnd)" target="_blank" lang="en"
-                                                class="@(hundredPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                class="@(hundredPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink print-link">
                                                 @hundredPos.JobGroupLevelCode @hundredPos.JobTitleEng
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
                                             <a href="/Similar/Edit?id=@hundredPos.JobTitleId&percent=100@(urlEnd)" target="_blank" lang="fr"
-                                                class="@(hundredPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                class="@(hundredPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow print-link">
                                                 @hundredPos.JobGroupLevelCode @hundredPos.JobTitleFre
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
@@ -290,12 +288,12 @@ else
                                         @if (ninetyPos != null)
                                         {
                                             <a href="/Similar/Edit?id=@ninetyPos.JobTitleId&percent=90@(urlEnd)" target="_blank" lang="en"
-                                                class="@(ninetyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                class="@(ninetyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink print-link">
                                                 @ninetyPos.JobGroupLevelCode @ninetyPos.JobTitleEng
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
                                             <a href="/Similar/Edit?id=@ninetyPos.JobTitleId&percent=90@(urlEnd)" target="_blank" lang="fr"
-                                                class="@(ninetyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                class="@(ninetyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow print-link">
                                                 @ninetyPos.JobGroupLevelCode @ninetyPos.JobTitleFre
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
@@ -324,12 +322,12 @@ else
                                         @if (eightyPos != null)
                                         {
                                             <a href="/Similar/Edit?id=@eightyPos.JobTitleId&percent=80@(urlEnd)" target="_blank" lang="en"
-                                                class="@(eightyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                class="@(eightyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink print-link">
                                                 @eightyPos.JobGroupLevelCode @eightyPos.JobTitleEng
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
                                             <a href="/Similar/Edit?id=@eightyPos.JobTitleId&percent=80@(urlEnd)" target="_blank" lang="fr"
-                                                class="@(eightyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                class="@(eightyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow print-link">
                                                 @eightyPos.JobGroupLevelCode @eightyPos.JobTitleFre
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
@@ -358,12 +356,12 @@ else
                                         @if (seventyPos != null)
                                         {
                                             <a href="/Similar/Edit?id=@seventyPos.JobTitleId&percent=70@(urlEnd)" target="_blank" lang="en"
-                                                class="@(seventyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink">
+                                                class="@(seventyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink print-link">
                                                 @seventyPos.JobGroupLevelCode @seventyPos.JobTitleEng
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>
                                             <a href="/Similar/Edit?id=@seventyPos.JobTitleId&percent=70@(urlEnd)" target="_blank" lang="fr"
-                                                class="@(seventyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow">
+                                                class="@(seventyPos.JobTitleId == Model.PositionBengLocated.JobTitleId ? "bold" : "") rememberIfVisited nextOrPreviousLink dontShow print-link">
                                                 @seventyPos.JobGroupLevelCode @seventyPos.JobTitleFre
                                                 <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
                                             </a>

--- a/Admin/Pages/Similar/Locate.cshtml
+++ b/Admin/Pages/Similar/Locate.cshtml
@@ -189,7 +189,7 @@ else
             eightyPositions.Count(), seventyPositions.Count(), };
         int numRows = arrayLengths.Max();
 
-        <div id="table-container">
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
             <table class="table">
                 <thead>
                     <tr class="table-header-row text-center">

--- a/Admin/Pages/Similar/Locate.cshtml
+++ b/Admin/Pages/Similar/Locate.cshtml
@@ -114,7 +114,7 @@
 {
     @if (itemsThatMatchFilter.Any())
     {
-        <div id="table-container">
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
             <table class="table">
                 <thead>
                     <tr class="table-header-row text-center">

--- a/Admin/Pages/Similar/Locate.cshtml.cs
+++ b/Admin/Pages/Similar/Locate.cshtml.cs
@@ -32,6 +32,8 @@ namespace Admin.Pages.Similar
 
         public bool DisplayTopOfPage { get; set; }
 
+        public double LastTableContainerHeight { get; set; } = 300;
+
         public bool LocatingAPosition { get; set; } = false;
 
         public JobPositionDto PositionBengLocated { get; set; }
@@ -53,6 +55,17 @@ namespace Admin.Pages.Similar
                 if (sessionStr.ToLower() == "false")
                 {
                     DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
                 }
             }
 

--- a/Admin/Startup.cs
+++ b/Admin/Startup.cs
@@ -14,6 +14,7 @@ using DataModel;
 using Microsoft.EntityFrameworkCore;
 using SimpleInjector;
 using Admin.Config;
+using Admin.Data;
 
 namespace Admin
 {
@@ -36,6 +37,7 @@ namespace Admin
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
+            services.AddTransient<FormattingService>();
             services.AddDistributedMemoryCache();
 
             services.AddSession(options => {

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -698,7 +698,7 @@ textarea.big-textarea {
 }
 
 .highlighted {
-    background-color: yellow !important;
+    background-color: #f2fdb2 !important;
 }
 
 .overflow-y-auto {

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -207,7 +207,7 @@ h4.no-results {
     }
 
 .remove-btn {
-    color: red;
+    color: var(--btnDangerColour);
     font-weight: bold;
 }
 
@@ -272,7 +272,7 @@ h4.no-results {
         #table-container table thead {
             position: sticky;
             top: 0px;
-            z-index: 100 !important;
+            z-index: 10 !important;
             background-color: white;
         }
 
@@ -411,7 +411,7 @@ textarea.form-control {
 .navbar {
     height: 66px !important;
     max-height: 66px !important;
-    overflow-y: hidden;
+    overflow-y: visible;
 }
 
 *.no-padding {
@@ -420,6 +420,10 @@ textarea.form-control {
 
 .no-padding-right {
     padding-right: 0px !important;
+}
+
+.no-padding-bottom {
+    padding-bottom: 0px !important;
 }
 
 .nav-item {
@@ -440,7 +444,11 @@ textarea.form-control {
     cursor: default !important;
 }
 
-.nav-item:not(.selected) .nav-link:hover, .navbar-brand:hover, .nav-item:not(.selected), .nav-link.visited, .navbar-brand.visited {
+.dropdown-content .nav-link:hover {
+    cursor: pointer !important;
+}
+
+.nav-item:not(.selected) .nav-link:hover, .navbar-brand:hover, .nav-item:not(.selected), .nav-link.visited, .navbar-brand.visited, .dropdown-content .nav-link:hover {
     color: var(--btnPrimary) !important;
 }
 
@@ -458,6 +466,8 @@ textarea.form-control {
     padding-bottom: 0px;
     border-bottom: 6px solid var(--btnPrimary) !important;
     transition: border-bottom 0.3s !important;
+    height: 65px;
+    overflow-y: visible;
 }
 
 .smooth-underline::after {
@@ -607,6 +617,10 @@ a.visited {
     margin-right: 0px !important;
 }
 
+.margin-right-space-btn {
+    margin-right: 15px !important;
+}
+
 .vertical-margin-auto {
     margin-top: auto;
     margin-bottom: auto;
@@ -671,6 +685,122 @@ textarea.big-textarea {
 * {
     word-wrap: break-word !important;
     word-break: break-word !important;
+    scroll-margin: 20px;
+}
+
+.field-validation-valid {
+    display: none !important;
+}
+
+.locate-page-save-icon {
+    top: 4px !important; 
+    right: 5px;
+}
+
+.highlighted {
+    background-color: yellow !important;
+}
+
+.overflow-y-auto {
+    overflow-y: auto;
+}
+
+.modal-footer {
+    padding-right: 0px !important;
+    padding-bottom: 0px !important;
+}
+
+.modal-footer .btn:first-of-type {
+    margin-right: 15px !important;
+}
+
+.modal-footer a.btn:first-of-type {
+    margin-right: 0px !important;
+}
+
+.nav-item > a {
+    background-color: white;
+    z-index: 1000 !important;
+    position: relative;
+    opacity: 1;
+}
+
+header {
+    z-index: 1000;
+}
+
+.dropdown-content {
+    position: absolute;
+    background-color: white;
+    box-shadow: none;
+    border: 2px solid var(--btnSecondaryColour);
+    border-top: none;
+    padding: 8px 6px;
+    border-bottom-left-radius: 15px;
+    border-bottom-right-radius: 15px;
+    width: 116px !important;
+    opacity: 0;
+    top: -90px;
+    transition: all 0.3s cubic-bezier(0.41,-0.05, 0.78, 1.14);
+    z-index: 100;
+}
+
+.dropdown-content a {
+    display: block;
+    margin-top: 0px;
+    padding-bottom: 0px;
+    width: fit-content !important;
+    max-width: fit-content !important;
+}
+
+.dropdown-content a:first-child {
+    padding-top: 3px;
+}
+
+#navCompetencies:hover .dropdown-content, #navCompetencies.hovered .dropdown-content {
+    opacity: 1;
+    top: 65px;
+    box-shadow: 0px 8px 16px 0px rgba(0,0,0,0.2);
+}
+
+#navHider, #bottomNavHider {
+    position: absolute;
+    left: 0px;
+    background-color: white;
+    width: 100%;
+    z-index: 10000;
+}
+
+#navHider {
+    top: -1px;
+    height: 8px;
+}
+
+#bottomNavHider {
+    top: 56px;
+    height: 2px;
+}
+
+#compNavHider {
+    position: absolute;
+    top: 59px;
+    left: 0px;
+    background-color: white;
+    height: 5px;
+    width: 116.11px;
+    z-index: 10000;
+}
+
+.dropdown-menu {
+    max-height: 800px;
+    overflow-y: auto;
+    min-width: fit-content;
+    overflow-x: hidden;
+    z-index: 10000;
+}
+
+.dropdown-menu.limit-height {
+    max-height: 500px !important;
 }
 
 @media print {
@@ -701,6 +831,22 @@ textarea.big-textarea {
 
     .col-4 {
         width: 33.33% !important;
+    }
+
+    .col-5 {
+        width: 41.66% !important;
+    }
+
+    .print-link {
+        color: rgb(3, 102, 214) !important;
+    }
+
+    .underline {
+        text-decoration: underline !important;
+    }
+
+    .print-underline {
+        text-decoration: underline !important;
     }
 
     #table-container {

--- a/Admin/wwwroot/js/site.js
+++ b/Admin/wwwroot/js/site.js
@@ -971,8 +971,10 @@ function removeHighlights() {
 function positionCompNavHider() {
     let compNavHider = qs("#compNavHider");
     let compNav = qs("#navCompetencies");
-    compNavHider.style.left = `${compNav.getBoundingClientRect().x - 1}px`;
-    compNavHider.style.width = `${compNav.getBoundingClientRect().width}px`;
+    if (compNav && compNavHider) {
+        compNavHider.style.left = `${compNav.getBoundingClientRect().x - 1}px`;
+        compNavHider.style.width = `${compNav.getBoundingClientRect().width}px`;
+    }
 }
 
 /**

--- a/Admin/wwwroot/js/site.js
+++ b/Admin/wwwroot/js/site.js
@@ -14,7 +14,7 @@ const MARGIN_BETWEEN_FOOTER_AND_TABLE = 30;
  * 
  * @param {string} selector - The string which represents the desired selection
  * @param {Element} parent - Optional: the parent on which the selection is made (default is document)
- * @returns - HTMLElement[]
+ * @returns HTMLElement[] | []
  * 
  */
 function qsa(selector, parent = document) {
@@ -35,7 +35,7 @@ function qsa(selector, parent = document) {
  * 
  * @param {string} selector - The string which represents the desired selection
  * @param {Element} parent - Optional: the parent on which the selection is made (default is document)
- * @returns - HTMLElement
+ * @returns HTMLElement | null
  * 
  */
 function qs(selector, parent = document) {
@@ -50,7 +50,7 @@ function qs(selector, parent = document) {
  * 
  * @param {HTMLElement} el - The child element
  * @param {string} parentTagName - The tag name of the parent desired, for exmaple "div"
- * @returns - HTMLElement
+ * @returns HTMLElement | null
  * 
  */
 function findNearestParentOfType(el, parentTagName) {
@@ -84,7 +84,7 @@ function findNearestParentOfType(el, parentTagName) {
  * 
  * @param {HTMLSelectElement} dropdown - The "select" HTML element
  * @param {Boolean} maximum - True by default. If set to true, will return the maximum, and the minimum otherwise
- * @returns Number
+ * @returns Number | null
  * 
  */
 function getMaximumOrMinimumValueFromDropdown(dropdown, maximum = true) {
@@ -102,7 +102,7 @@ function getMaximumOrMinimumValueFromDropdown(dropdown, maximum = true) {
 /**
  * This function is a simple API to set session variables on the server. There is a corresponding route in the app which receives a key value pair and sets it accordingly in the session.
  * 
- * @param {string} key - The key to set
+ * @param {string} key - The session key to set
  * @param {string} value - The value to give to the key
  * 
  */
@@ -120,7 +120,10 @@ function setSessionVariable(key, value) {
  * 
  */
 function canElementBeScrolled(el) {
-    return el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+    if (el) {
+        return el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
+    }
+    return false;
 }
 
 // Utility functions ^^^^^ -----------------------------------------------------------------------------------------------------------------
@@ -135,7 +138,7 @@ function storeCurrentScrollPosition() {
 }
 
 /**
- * This function gets called when the page loads and when the window is resized. It makes sure that on index pages, if there are buttons on the right side of the screen (buttons that switch between competency types for example), they stay aligned with the end of the table, based on if it can scroll or not
+ * This function gets called when the page loads and when the window is resized. It makes sure that on index pages, if there are buttons on the right side of the screen (buttons that switch between competency types for example), they stay aligned with the end of the table, based on if it can scroll or not.
  */
 function checkIfTableCanBeScrolled() {
     let btns = qsa(".index-right-button");
@@ -181,26 +184,31 @@ function checkIfTableCanBeScrolled() {
  * @param {string} portionToUpdate - This string represents the portion of the formaction string that is of concern, for example, "addedcertificateids"
  * @param {Number} elementId - The database id of the element in the portion to update to be updated. For example, if the element being updated was a competency, this parameter would be the id of the competency
  * @param {Number} newId - The value to apply to that specific element. This won't change the id, but the value of the item associated with that id. For example, for competencies, this is the value of the new level of the competency. For certificates, this is the id of the new certificate description
- * @returns string
+ * @returns string | null
  * 
  */
 function updateFormActionString(formActionStr, portionToUpdate, elementId, newId) {
-    let itemsIdsStr = formActionStr.substring((formActionStr.indexOf(portionToUpdate) + portionToUpdate.length + 1),
-        (formActionStr.indexOf("-&", (formActionStr.indexOf(portionToUpdate) + 1))));
+    try {
+        let itemsIdsStr = formActionStr.substring((formActionStr.indexOf(portionToUpdate) + portionToUpdate.length + 1),
+            (formActionStr.indexOf("-&", (formActionStr.indexOf(portionToUpdate) + 1))));
 
-    let endIndex = itemsIdsStr.indexOf("-", (itemsIdsStr.indexOf(elementId.toString().concat(ENCODED_AMPERSAND)))) < 0 ? itemsIdsStr.length :
-        itemsIdsStr.indexOf("-", (itemsIdsStr.indexOf(elementId.toString().concat(ENCODED_AMPERSAND))));
+        let endIndex = itemsIdsStr.indexOf("-", (itemsIdsStr.indexOf(elementId.toString().concat(ENCODED_AMPERSAND)))) < 0 ? itemsIdsStr.length :
+            itemsIdsStr.indexOf("-", (itemsIdsStr.indexOf(elementId.toString().concat(ENCODED_AMPERSAND))));
 
-    let itemToUpdateStr = itemsIdsStr.substring((itemsIdsStr.indexOf(elementId.toString().concat(ENCODED_AMPERSAND))),
-        endIndex);
+        let itemToUpdateStr = itemsIdsStr.substring((itemsIdsStr.indexOf(elementId.toString().concat(ENCODED_AMPERSAND))),
+            endIndex);
 
-    let updatedStr = itemToUpdateStr.substring(0, itemToUpdateStr.indexOf(ENCODED_AMPERSAND) + ENCODED_AMPERSAND.length).concat(newId.toString());
+        let updatedStr = itemToUpdateStr.substring(0, itemToUpdateStr.indexOf(ENCODED_AMPERSAND) + ENCODED_AMPERSAND.length).concat(newId.toString());
 
-    let formActionStrArr = formActionStr.split('');
-    formActionStrArr.splice(formActionStr.indexOf(itemToUpdateStr), itemToUpdateStr.length, updatedStr);
-    let updatedFormActionStr = formActionStrArr.join('');
+        let formActionStrArr = formActionStr.split('');
+        formActionStrArr.splice(formActionStr.indexOf(itemToUpdateStr), itemToUpdateStr.length, updatedStr);
+        let updatedFormActionStr = formActionStrArr.join('');
 
-    return updatedFormActionStr;
+        return updatedFormActionStr;
+    }
+    catch {
+        return null;
+    }
 }
 
 /**
@@ -215,12 +223,16 @@ function getNonEmptyTableCellsInColumn(columnIndex, tableRows) {
     let allRowElements = [];
     for (let i = 0; i < tableRows.length; i++) {
         let elements = qsa("td", tableRows[i]);
-        let element = elements[columnIndex];
-        for (let j = 0; j < element.childElementCount; j++) {
-            if (elements[columnIndex].children[j].nodeName) {
-                if (elements[columnIndex].children[j].nodeName.toLowerCase() === "a") {
-                    if (elements[columnIndex].children[j].textContent.trim() !== "") {
-                        allRowElements[i] = /** @type {HTMLElement} */ (elements[columnIndex].cloneNode(true));
+        if (elements.length > 0) {
+            let element = elements[columnIndex];
+            if (element) {
+                for (let j = 0; j < element.childElementCount; j++) {
+                    if (elements[columnIndex].children[j].nodeName) {
+                        if (elements[columnIndex].children[j].nodeName.toLowerCase() === "a") {
+                            if (elements[columnIndex].children[j].textContent.trim() !== "") {
+                                allRowElements[i] = /** @type {HTMLElement} */ (elements[columnIndex].cloneNode(true));
+                            }
+                        }
                     }
                 }
             }
@@ -463,30 +475,32 @@ function changeCompetencyLevelValue(el, newNum = null) {
  */
 function attemptToExpandCompetency(el) {
     if (el) {
-        let parentDiv = null;
-        let currentEl = el;
-        if (currentEl.classList) {
-            if (!currentEl.classList.contains("plus-minus-icon")) { // the element should not be toggled if you double-clicked on the + or - buttons
-                while (!parentDiv) {
-                    if (currentEl.classList) {
-                        if (currentEl.classList.contains("compLevelDescContainer")) {
-                            parentDiv = currentEl;
+        if (qs(".compLevelDescContainer")) {
+            let parentDiv = null;
+            let currentEl = el;
+            if (currentEl.classList) {
+                if (!currentEl.classList.contains("plus-minus-icon")) { // the element should not be toggled if you double-clicked on the + or - buttons
+                    while (!parentDiv) {
+                        if (currentEl.classList) {
+                            if (currentEl.classList.contains("compLevelDescContainer")) {
+                                parentDiv = currentEl;
+                            }
                         }
-                    }
-                    if (!parentDiv) {
-                        if (currentEl.parentElement) {
-                            currentEl = currentEl.parentElement;
-                        }
-                        else {
-                            break;
+                        if (!parentDiv) {
+                            if (currentEl.parentElement) {
+                                currentEl = currentEl.parentElement;
+                            }
+                            else {
+                                break;
+                            }
                         }
                     }
                 }
             }
-        }
-
-        if (parentDiv) {
-            qs(".btn.dontShow", parentDiv).click();
+    
+            if (parentDiv) {
+                qs(".btn.dontShow", parentDiv).click();
+            }
         }
     }
 }
@@ -529,12 +543,15 @@ function setTableContainerMaxHeight() {
         let noResultColumns = qsa(".no-matching-positions-at-percent");
         if (noResultColumns.length > 0) {
             let thead = qs("thead", tableContainer);
-            for (let i = 0; i < noResultColumns.length; i++) {
-                let span = qs("span", noResultColumns[i]);
-                let top = ((tableContainer.getBoundingClientRect().height - span.getBoundingClientRect().height - thead.getBoundingClientRect().height) / 2) + thead.getBoundingClientRect().height;
-                span.style.top = `${top}px`;
+            if (thead) {
+                for (let i = 0; i < noResultColumns.length; i++) {
+                    let span = qs("span", noResultColumns[i]);
+                    let top = ((tableContainer.getBoundingClientRect().height - span.getBoundingClientRect().height - thead.getBoundingClientRect().height) / 2) + thead.getBoundingClientRect().height;
+                    span.style.top = `${top}px`;
+                }
             }
         }
+        setSessionVariable("lastTableContainerHeight", newHeight.toString());
     }
 }
 
@@ -948,13 +965,13 @@ function smoothScrollToElement(el, location = "start", highlightElement = false,
             el.classList.add("highlighted")
         }
         setTimeout(() => {
-            el.scrollIntoView({behavior: "smooth", block: location, inline: "nearest"});
+            el.scrollIntoView({ behavior: "smooth", block: location, inline: "nearest" });
         }, 100)
     }
 }
 
 /**
- * This function gets called whenever the user clicks on the screen. It removes the highlight effect of any elements (if applicable)
+ * This function gets called whenever the user clicks on the screen. It removes the highlight effect of any elements (if applicable).
  */
 function removeHighlights() {
     if (qs(".highlighted")) {
@@ -966,7 +983,7 @@ function removeHighlights() {
 }
 
 /**
- * This function positions a tiny element in the navigation which hides the space below the "Competencies" link, which otherwise has a weird effect when the dropdown options appear.
+ * This function positions a tiny element in the navigation which hides the space below the "Competencies" link, which otherwise has a weird effect when the dropdown options appear on hover.
  */
 function positionCompNavHider() {
     let compNavHider = qs("#compNavHider");
@@ -979,7 +996,7 @@ function positionCompNavHider() {
 
 /**
  * 
- * This function makes it so if you are hovering over the Competencies link in the navigation, it will ensure that the dropdown options will display. This is because of a weird space that existed in between the actual "Competencies" link and the dropdown, where the hover effect wouldn't apply.
+ * This function makes it so if you are hovering over the Competencies link in the navigation, it will ensure that the dropdown options will display. This is because of a weird space that otherwise exists between the actual "Competencies" link and the dropdown, where the hover effect wouldn't apply.
  * 
  * @param {MouseEvent} e - The mouseover event
  * 
@@ -988,8 +1005,8 @@ function checkIfCompetencyDropdownShouldDisplay(e) {
     let navComp = qs("#navCompetencies");
     if (navComp) {
         let navCompRect = navComp.getBoundingClientRect();
-        if ((e.pageX > navCompRect.x && e.pageX < (navCompRect.x + navCompRect.width)) && 
-        (e.pageY < navCompRect.height + 1)) {
+        if ((e.pageX > navCompRect.x && e.pageX < (navCompRect.x + navCompRect.width)) &&
+            (e.pageY < navCompRect.height + 1)) {
             navComp.classList.add("hovered");
         }
         else {
@@ -1003,7 +1020,7 @@ function checkIfCompetencyDropdownShouldDisplay(e) {
 // Page startup functions VVVVV ------------------------------------------------------------------------------------------------------------
 
 /**
- * This function gets called whenever a page loads. It indicates in the navigation in which group of pages the user is currently in by adding a blue border below the link
+ * This function gets called whenever a page loads. It indicates in the navigation in which group of pages the user is currently in by adding a blue border below the link.
  */
 function setSelectedNavItem() {
     let url = window.location.href.toLowerCase();
@@ -1059,7 +1076,7 @@ function setSelectedNavItem() {
 }
 
 /**
- * This function gets called whenever a page loads, and simply checks localStorage to see if a window scroll offset it set there (which can be set by the storeCurrentScrollPosition() function). If there is, it will apply this offset to the window, bringing you back to the same scroll position you had before reloading the page (useful in certain forms)
+ * This function gets called whenever a page loads, and simply checks localStorage to see if a window scroll offset it set there (which can be set by the storeCurrentScrollPosition() function). If there is, it will apply this offset to the window, bringing users back to the same scroll position they had before reloading the page (useful in certain forms).
  */
 function checkIfWindowShouldBeScrolled() {
     let scrollValue = localStorage.getItem(localStorageScrollStr);
@@ -1115,25 +1132,27 @@ function checkIfAnElementShouldBeScrolledIntoView() {
         if (qStringParts[i].includes("=")) {
             let keyValuePair = qStringParts[i].split("=");
             let key = keyValuePair[0];
-            let value = keyValuePair[1];
-
-            let shortValue = value;
-            if (value.includes("_")) {
-                shortValue = value.substring(0, value.indexOf("_"));
-            }
-
-            let location = "start";
-            if (value.includes("_b")) {
-                location = "end";
-            }
-            if (value.includes("_c")) {
-                location = "center";
-            }
-            if (value.includes("_n")) {
-                location = "nearest";
-            }
 
             if (key.toLowerCase() === "scrollto") {
+                let value = keyValuePair[1];
+
+                let shortValue = value;
+                if (value.includes("_")) {
+                    shortValue = value.substring(0, value.indexOf("_"));
+                    value = value.toLowerCase();
+                }
+
+                let location = "start";
+                if (value.includes("_b")) {
+                    location = "end";
+                }
+                if (value.includes("_c")) {
+                    location = "center";
+                }
+                if (value.includes("_n")) {
+                    location = "nearest";
+                }
+
                 if (qs(`#${shortValue}`)) {
                     smoothScrollToElement(qs(`#${shortValue}`), location, value.includes("_h"), value.includes("_o"));
                     return;

--- a/Admin/wwwroot/js/site.js
+++ b/Admin/wwwroot/js/site.js
@@ -10,12 +10,12 @@ const MARGIN_BETWEEN_FOOTER_AND_TABLE = 30;
 // Utility functions VVVVV -----------------------------------------------------------------------------------------------------------------
 
 /**
+ * The same querySelectorAll function that you know, expect this one returns an array of HTMLElements, and you don't call it on anything, you can simply pass an optional parent parameter to it. Returns an empty array in case no elements match.
  * 
  * @param {string} selector - The string which represents the desired selection
  * @param {Element} parent - Optional: the parent on which the selection is made (default is document)
  * @returns - HTMLElement[]
  * 
- * The same querySelectorAll function that you know, expect this one returns an array of HTMLElements, and you don't call it on anything, you can simply pass an optional parent parameter to it. Returns an empty array in case no elements match.
  */
 function qsa(selector, parent = document) {
     if ((!selector) || (!parent)) {
@@ -31,12 +31,12 @@ function qsa(selector, parent = document) {
 }
 
 /**
+ * The same querySelector function that you know, expect this one returns a HTMLElement, and you don't call it on anything, you can simply pass an optional parent parameter to it.
  * 
  * @param {string} selector - The string which represents the desired selection
  * @param {Element} parent - Optional: the parent on which the selection is made (default is document)
  * @returns - HTMLElement
  * 
- * The same querySelector function that you know, expect this one returns a HTMLElement, and you don't call it on anything, you can simply pass an optional parent parameter to it.
  */
 function qs(selector, parent = document) {
     if ((!selector) || (!parent)) {
@@ -46,12 +46,12 @@ function qs(selector, parent = document) {
 }
 
 /**
+ * This function is meant to help find the nearest parent of an element of a certain type. It is limited to the tag name, meaning you can't use the full querySelector options. If no parent can be found, null will be returned.
  * 
  * @param {HTMLElement} el - The child element
  * @param {string} parentTagName - The tag name of the parent desired, for exmaple "div"
  * @returns - HTMLElement
  * 
- * This function is meant to help find the nearest parent of an element of a certain type. It is limited to the tag name, meaning you can't use the full querySelector options. If no parent can be found, null will be returned.
  */
 function findNearestParentOfType(el, parentTagName) {
     if ((!el) || (!parentTagName)) {
@@ -80,12 +80,12 @@ function findNearestParentOfType(el, parentTagName) {
 }
 
 /**
+ * This function returns the maximum or minimum "value" attribute of all option elements contained within the dropdown. Returns null if there are no options in the dropdown.
  * 
  * @param {HTMLSelectElement} dropdown - The "select" HTML element
  * @param {Boolean} maximum - True by default. If set to true, will return the maximum, and the minimum otherwise
  * @returns Number
  * 
- * This function returns the maximum or minimum "value" attribute of all option elements contained within the dropdown. Returns null if there are no options in the dropdown.
  */
 function getMaximumOrMinimumValueFromDropdown(dropdown, maximum = true) {
     let dropdownOptions = qsa("option", dropdown);
@@ -100,11 +100,11 @@ function getMaximumOrMinimumValueFromDropdown(dropdown, maximum = true) {
 }
 
 /**
+ * This function is a simple API to set session variables on the server. There is a corresponding route in the app which receives a key value pair and sets it accordingly in the session.
  * 
  * @param {string} key - The key to set
  * @param {string} value - The value to give to the key
  * 
- * This function is a simple API to set session variables on the server. There is a corresponding route in the app which receives a key value pair and sets it accordingly in the session.
  */
 function setSessionVariable(key, value) {
     if (key && value) {
@@ -113,11 +113,11 @@ function setSessionVariable(key, value) {
 }
 
 /**
+ * This function determines if an element can be scrolled (has a scrollbar).
  * 
  * @param {HTMLElement} el 
  * @returns boolean
  * 
- * This function determines if an element can be scrolled (has a scrollbar)
  */
 function canElementBeScrolled(el) {
     return el.scrollWidth > el.clientWidth || el.scrollHeight > el.clientHeight;
@@ -175,6 +175,7 @@ function checkIfTableCanBeScrolled() {
 }
 
 /**
+ * This function updates the formaction string of an element whenever a certificate's description is changed, or whenever a competency level is modified.
  * 
  * @param {string} formActionStr - The string that correponds to the "formaction" attribute of the element being updated
  * @param {string} portionToUpdate - This string represents the portion of the formaction string that is of concern, for example, "addedcertificateids"
@@ -182,7 +183,6 @@ function checkIfTableCanBeScrolled() {
  * @param {Number} newId - The value to apply to that specific element. This won't change the id, but the value of the item associated with that id. For example, for competencies, this is the value of the new level of the competency. For certificates, this is the id of the new certificate description
  * @returns string
  * 
- * This function updates the formaction string of an element whenever a certificate's description is changed, or whenever a competency level is modified.
  */
 function updateFormActionString(formActionStr, portionToUpdate, elementId, newId) {
     let itemsIdsStr = formActionStr.substring((formActionStr.indexOf(portionToUpdate) + portionToUpdate.length + 1),
@@ -204,12 +204,12 @@ function updateFormActionString(formActionStr, portionToUpdate, elementId, newId
 }
 
 /**
+ * This function is used to retrieve the td elements that are not empty in the table column specified by the parameter. This happens when sorting/reversing the column. There is logic in place to ensure that only the elements that are not empty are retrieved, since the table in question (the results of the located similar position) may not have an equal number of elements per row, so some cells may be empty.
  * 
  * @param {Number} columnIndex - The index of the column from which the table cells should be retrieved
  * @param {HTMLElement[]} tableRows - The HTML "tr" elements of the main table
  * @returns HTMLElement[]
  * 
- * This function is used to retrieve the td elements that are not empty in the table column specified by the parameter. This happens when sorting/reversing the column. There is logic in place to ensure that only the elements that are not empty are retrieved, since the table in question (the results of the located similar position) may not have an equal number of elements per row, so some cells may be empty.
  */
 function getNonEmptyTableCellsInColumn(columnIndex, tableRows) {
     let allRowElements = [];
@@ -234,11 +234,11 @@ function getNonEmptyTableCellsInColumn(columnIndex, tableRows) {
 // Competency level functions VVVVV --------------------------------------------------------------------------------------------------------
 
 /**
+ * This function is used on tables headers where the elements in the next rows are expandable, for instance in the add/edit/details position page, where you can expand competencies and certificates. This function toggles every expandable element in that table, or in the case of the details page, where there are multiple subsections to the same large table, it expands every element until it meets the next "header" row of the table.
  * 
  * @param {Element} el - The element whose siblings contained in the next table rows are to be expanded (usually a table header)
  * 
- * This function is used on tables headers where the elements in the next rows are expandable, for instance in the add/edit/details position page, where you can expand competencies and certificates. This function toggles every expandable element in that table, or in the case of the details page, where there are multiple subsections to the same large table, it expands every element until it meets the next "header" row of the table.
-*/
+ */
 function toggleExpandableElementsInNextRows(el) {
     let columnAffected = 1;
     let nearestParentRow = findNearestParentOfType(el, "tr");
@@ -312,10 +312,10 @@ function toggleExpandableElementsInNextRows(el) {
 }
 
 /**
+ * This function gets called whenever a dropdown to change a competency's level gets updated, either by the dropdown itself, or by the + or - buttons. It ensures that if the dropdown is at its maximum or minimum value, the corresponding button gets disabled (and re-enabled if the value changes again and is no longer at an extreme).
  * 
  * @param {HTMLSelectElement} dropdown - The dropdown which had its value updated
  * 
- * This function gets called whenever a dropdown to change a competency's level gets updated, either by the dropdown itself, or by the + or - buttons. It ensures that if the dropdown is at its maximum or minimum value, the corresponding button gets disabled (and re-enabled if the value changes again and is no longer at an extreme).
  */
 function checkCompetencyLevelButtonsState(dropdown) {
     if (dropdown) {
@@ -339,10 +339,10 @@ function checkCompetencyLevelButtonsState(dropdown) {
 }
 
 /**
+ * This function gets called whenever the user modifies the level of a competency in edit/create position, either by using the buttons, or by using the dropdown. It will adjust the competency level description to match that of the new level. You can see this description by expanding the "LEVEL / NIVEAU" column of the competency tables. (Note, the data for the competency level descriptions is simply hidden in the page, and it gets queried from there).
  * 
  * @param {HTMLSelectElement} dropdown - The dropdown representing the competency level which had its value modified
  * 
- * This function gets called whenever the user modifies the level of a competency in edit/create position, either by using the buttons, or by using the dropdown. It will adjust the competency level description to match that of the new level. You can see this description by expanding the "LEVEL / NIVEAU" column of the competency tables. (Note, the data for the competency level descriptions is simply hidden in the page, and it gets queried from there).
  */
 function setCompetencyLevelDescription(dropdown) {
     if (dropdown) {
@@ -382,11 +382,11 @@ function setCompetencyLevelDescription(dropdown) {
 }
 
 /**
+ * This function replaces all formaction attributes on the page (add/edit position) whenever a competency level is changed. In doing so, users are able to change the level of a competency without having to remove and add the competency again. If the function gets called by pressing the + or - button, this function also replaces the associated dropdown with the updated number.
  * 
  * @param {HTMLElement} el - The HTMLElement which caused the function to be called, either a + or - button, or a competency level dropdown
  * @param {Number} newNum - The new competency level. It will be set if this function gets called by selecting the dropdown value
  * 
- * This function replaces all formaction attributes on the page (add/edit position) whenever a competency level is changed. In doing so, users are able to change the level of a competency without having to remove and add the competency again. If the function gets called by pressing the + or - button, this function also replaces the associated dropdown with the updated number.
  */
 function changeCompetencyLevelValue(el, newNum = null) {
     let newDropdownValue;
@@ -456,10 +456,10 @@ function changeCompetencyLevelValue(el, newNum = null) {
 }
 
 /**
+ * This function gets called when the user double clicks anywhere on the page, but it only does something if they clicked on a competency that can be expanded (on the edit position page). If they clicked on such a competency, this function will toggle expanding/collapsing that competency.
  * 
  * @param {HTMLElement} el - The element that was clicked
  * 
- * This function gets called when the user double clicks anywhere on the page, but it only does something if they clicked on a competency that can be expanded (on the edit position page). If they clicked on such a competency, this function will toggle expanding/collapsing that competency
  */
 function attemptToExpandCompetency(el) {
     if (el) {
@@ -525,7 +525,7 @@ function setTableContainerMaxHeight() {
         tableContainer.style.maxHeight = `${newHeight}px`;
         tableContainer.style.minHeight = `${newHeight}px`;
 
-        // this code handles centering vertically the text that appears when a position could not be found in a percentage in the locate similar position feature
+        // this code handles centering vertically the text that appears when a position could not be found in a percentage in the locate similar positions feature
         let noResultColumns = qsa(".no-matching-positions-at-percent");
         if (noResultColumns.length > 0) {
             let thead = qs("thead", tableContainer);
@@ -539,10 +539,10 @@ function setTableContainerMaxHeight() {
 }
 
 /**
+ * This function gets called when the user changes a certificate that has been added to a position's description, by selecting it in the dropdown. Similarly to the changeCompetencyLevelValue() function, this function changes the formaction attribute of all elements in the page that have it to update the certificate description id of the certificate that was updated. This function also handles hiding/showing/updating the link that leads to the certificate description (it becomes hidden if the description selected is the empty one).
  * 
  * @param {HTMLSelectElement} dropdown - The certificate description dropdown that was modified
  * 
- * This function gets called when the user changes a certificate that has been added to a position's description, by selecting it in the dropdown. Similarly to the changeCompetencyLevelValue() function, this function changes the formaction attribute of all elements in the page that have it to update the certificate description id of the certificate that was updated. This function also handles hiding/showing/updating the link that leads to the certificate description (it becomes hidden if the description selected is the empty one).
  */
 function changeCertificateDescription(dropdown) {
     let selectedCertDescId = Number(dropdown.value);
@@ -576,10 +576,10 @@ function changeCertificateDescription(dropdown) {
 }
 
 /**
+ * This function is used on tables headers where the elements in the next rows are expandable, for instance in the add/edit/details position page, where you can expand competencies and certificates. This function toggles every expandable element in that table, or in the case of the details page, where there are multiple subsections to the same large table, it expands every element until it meets the next "header" row of the table.
  * 
  * @param {HTMLElement} el - The element whose siblings contained in the next table rows are to be expanded (usually a table header)
  * 
- * This function is used on tables headers where the elements in the next rows are expandable, for instance in the add/edit/details position page, where you can expand competencies and certificates. This function toggles every expandable element in that table, or in the case of the details page, where there are multiple subsections to the same large table, it expands every element until it meets the next "header" row of the table.
  */
 function toggleExpandableElementsInNextRows(el) {
     let columnAffected = 1;
@@ -654,10 +654,10 @@ function toggleExpandableElementsInNextRows(el) {
 }
 
 /**
+ * This function gets called when the user double clicks anywhere on the page, but it only does something if they clicked on a competency level that can be expanded (on the edit/create position page). If they clicked on such a competency, this function will toggle expanding/collapsing that competency.
  * 
  * @param {HTMLElement} el - The element that was double clicked
  * 
- * This function gets called when the user double clicks anywhere on the page, but it only does something if they clicked on a competency level that can be expanded (on the edit/create position page). If they clicked on such a competency, this function will toggle expanding/collapsing that competency
  */
 function attemptToExpandCompetency(el) {
     if (el) {
@@ -690,11 +690,11 @@ function attemptToExpandCompetency(el) {
 }
 
 /**
+ * This function sorts the tables in the index pages based on the column header that was clicked. The sort can be reversed by clicking the same column again. It also can sort the columns that display the number of matching positions per percentage, if the second parameter is set to true.
  * 
  * @param {HTMLElement} el - The column header that was clicked
  * @param {boolean} sortPercents - Whether the table being sorted is displaying the number of matching positions per percentage (only applicable in similar positions index page)
  * 
- * This function sorts the tables in the index pages based on the column header that was clicked. The sort can be reversed by clicking the same column again. It also can sort the columns that display the number of matching positions per percentage, if the second parameter is set to true.
  */
 function sortColumn(el, sortPercents = false) {
     if (el) {
@@ -799,10 +799,10 @@ function sortEveryColumn() {
 }
 
 /**
+ * This function reverses the elements in the table column. It is only used by the results table for located similar positions.
  * 
  * @param {HTMLElement} el - The column header that was clicked
  * 
- * This function reverses the elements in the table column. It is only used by the results table for located similar positions.
  */
 function flipColumn(el) {
     if (el) {
@@ -838,22 +838,22 @@ function flipColumn(el) {
 }
 
 /**
+ * This function gets called if users click on a link that says "Overwrite" when copying similar positions over. It sets up the link used by the modal window that makes users aware that they may overwrite data by copying over the similar positions. Since there is only one modal window and that it may be used by all "Overwrite" links, this function just makes sure that the modal window will have a link to the appropriate position.
  * 
  * @param {HTMLElement} el - The link that was clicked
  * 
- * This function gets called if users click on a link that says "Overwrite" when copying similar positions over. It sets up the link used by the modal window that makes users aware that they may overwrite data by copying over the similar positions. Since there is only one modal window and that it may be used by all "Overwrite" links, this function just makes sure that the modal window will have a link to the appropriate position.
  */
 function prepareOverwriteSimilarModalLink(el) {
     qs("#btn-modal-overwrite-similar").setAttribute("href", `/Similar/Create?id=${el.getAttribute("value")}&copyid=${qs("#position-copied-id").textContent}`);
 }
 
 /**
+ * This function gets called whenever a link is clicked on the located position results page, or in the navigation. It helps users keep track of which links they have clicked by making them a different colour. In the navigation, it just makes sure the link has the proper colour when loading the next page.
  * 
  * @param {HTMLElement} el - The link that was clicked
  * @param {boolean} targetSibling - Whether or not the sibling link should be made visited as well. It is true when the link comes from the locate positions page
  * @param {boolean} ctrlHeld - Whether or not the CTRL key was being held when the click happened
  * 
- * This function gets called whenever a link is clicked on the located position results page, or in the navigation. It helps users keep track of which links they have clicked by making them a different colour. In the navigation, it just makes sure the link has the proper colour when loading the next page.
  */
 function makeLinkVisited(el, targetSibling = true, ctrlHeld = false) {
     if (!ctrlHeld || targetSibling) {
@@ -875,10 +875,10 @@ function makeLinkVisited(el, targetSibling = true, ctrlHeld = false) {
 }
 
 /**
+ * This function is used on the located position results screen to alternate between displaying the French and English titles of positions. It is called by clicking the radio buttons associated to the languages. All this does is change CSS classes to hide/show elements.
  * 
  * @param {HTMLInputElement} el - The radio button that was clicked
  * 
- * This function is used on the located position results screen to alternate between displaying the French and English titles of positions. It is called by clicking the radio buttons associated to the languages. All this does is change CSS classes to hide/show elements.
  */
 function swapJobTitleLanguage(el) {
     let changingToEnglish = el.value.toLowerCase() === "eng";
@@ -982,6 +982,7 @@ function positionCompNavHider() {
  * This function makes it so if you are hovering over the Competencies link in the navigation, it will ensure that the dropdown options will display. This is because of a weird space that existed in between the actual "Competencies" link and the dropdown, where the hover effect wouldn't apply.
  * 
  * @param {MouseEvent} e - The mouseover event
+ * 
  */
 function checkIfCompetencyDropdownShouldDisplay(e) {
     let navComp = qs("#navCompetencies");
@@ -1046,12 +1047,14 @@ function setSelectedNavItem() {
 
     if (selectedItem === "navCompetencies") {
         let compNavHider = qs("#compNavHider");
-        compNavHider.style.backgroundColor = "transparent";
-        setTimeout(() => {
-            compNavHider.style.backgroundColor = "#0069d9";
-            compNavHider.style.top = "58px";
-            compNavHider.style.height = "6px";
-        }, 350);
+        if (compNavHider) {
+            compNavHider.style.backgroundColor = "transparent";
+            setTimeout(() => {
+                compNavHider.style.backgroundColor = "#0069d9";
+                compNavHider.style.top = "58px";
+                compNavHider.style.height = "6px";
+            }, 350);
+        }
     }
 }
 
@@ -1145,12 +1148,12 @@ function checkIfAnElementShouldBeScrolledIntoView() {
 // Handling Events VVVVV -------------------------------------------------------------------------------------------------------------------
 
 /**
+ * This function gets called whenever a transitionstart event is fired, so when an element is expanded/collapsed. It is mainly used on the index pages for toggling the top portion of the page.
  * 
  * @param {TransitionEvent} e - The event object
  * @param {boolean} canRecurse - Whether the function can call itself again, true by default (the function can call itself without recursing though)
  * @param {boolean} firstCall - Whether this is the first time it is called for this animation. Recursive calls have it set to false, and it is false by default
  * 
- * This function gets called whenever a transitionstart event is fired, so when an element is expanded/collapsed. It is mainly used on the index pages for toggling the top portion of the page.
  */
 function transitionStarted(e, canRecurse = true, firstCall = false) {
     let target = /** @type {HTMLInputElement} */ (e.target);
@@ -1220,11 +1223,11 @@ function mouseMoved(e) {
 }
 
 /**
+ * This function gets called whenever an input element has its value change, and in certain cases, it will call other functions to handle special baheviour.
  * 
  * @param {Event} e - The change event
  * @returns void
  * 
- * This function gets called whenever an input element has its value change, and in certain cases, it will call other functions to handle special baheviour.
  */
 function handleChange(e) {
     let target = /** @type {HTMLInputElement} */ (e.target);
@@ -1247,11 +1250,11 @@ function handleChange(e) {
 }
 
 /**
+ * This function gets called whenever a form is submitted and triggers other functions if necessary.
  * 
  * @param {SubmitEvent} e - The form submit event
  * @returns void
  * 
- * This function gets called whenever a form is submitted and triggers other functions if necessary.
  */
 function formSubmitted(e) {
     let target = /** @type {HTMLElement} */ (e.target);
@@ -1265,11 +1268,11 @@ function formSubmitted(e) {
 }
 
 /**
+ * This function gets called whenever something is double clicked on the page, to then dispatch the event to another function based on what was clicked and if something should happen in that case.
  * 
  * @param {MouseEvent} e - The double click event
  * @returns void
  * 
- * This function gets called whenever something is double clicked on the page, to then dispatch the event to another function based on what was clicked and if something should happen in that case.
  */
 function handleDoubleClick(e) {
     let target = /** @type {HTMLElement} */ (e.target);
@@ -1281,11 +1284,11 @@ function handleDoubleClick(e) {
 }
 
 /**
+ * This function gets called whenever something is clicked on the page, to then dispatch the event to another function based on what was clicked and if something should happen in that case.
  * 
  * @param {PointerEvent} e - The click event
  * @returns void
  * 
- * This function gets called whenever something is clicked on the page, to then dispatch the event to another function based on what was clicked and if something should happen in that case.
  */
 function handleClick(e) {
     let target = /** @type {HTMLElement} */ (e.target);

--- a/Admin/wwwroot/js/site.js
+++ b/Admin/wwwroot/js/site.js
@@ -525,8 +525,10 @@ function toggleRegionCheckboxes() {
 
 /**
  * This function is used on basically all Index pages, where there is a long list of elements to display. It handles setting the height of the element which contains the table and that can be scrolled through to make sure it takes up as much height as it can on screen without hiding anything. The minimum height for it is 300px.
+ * 
+ * @param {boolean} setHeightInSession - Whether or not the new table container height should be set in the session
  */
-function setTableContainerMaxHeight() {
+function setTableContainerMaxHeight(setHeightInSession = false) {
     footer = /** @type {HTMLElement} */ (footer);
     tableContainer = /** @type {HTMLElement} */ (tableContainer);
     windowHeight = /** @type {number} */ (windowHeight);
@@ -551,7 +553,9 @@ function setTableContainerMaxHeight() {
                 }
             }
         }
-        setSessionVariable("lastTableContainerHeight", newHeight.toString());
+        if (setHeightInSession) {
+            setSessionVariable("lastTableContainerHeight", newHeight.toString());
+        }
     }
 }
 
@@ -1224,7 +1228,7 @@ function transitionStarted(e, canRecurse = true, firstCall = false) {
                 qs("body").classList.remove("overflow-hidden");
                 setTableContainerMaxHeight();
                 setTimeout(() => { // this delayed call ensures that there can't be a desync, otherwise, it can happen, very rarely
-                    setTableContainerMaxHeight();
+                    setTableContainerMaxHeight(true);
                 }, 100);
             }
         }
@@ -1396,13 +1400,13 @@ window.addEventListener("load", () => {
 
     positionCompNavHider();
     if (tableContainer && footer) {
-        setTableContainerMaxHeight();
+        setTableContainerMaxHeight(true);
         checkIfTableCanBeScrolled();
     }
     window.addEventListener("resize", () => {
         if (tableContainer && footer) {
             windowHeight = window.innerHeight;
-            setTableContainerMaxHeight();
+            setTableContainerMaxHeight(true);
             checkIfTableCanBeScrolled();
         }
         positionCompNavHider();

--- a/Business.Commands/Admin/JobPositions/PostJobPositionCommandGetJobPositionIdQueryHandler.cs
+++ b/Business.Commands/Admin/JobPositions/PostJobPositionCommandGetJobPositionIdQueryHandler.cs
@@ -11,8 +11,8 @@ namespace Business.Commands.Admin.JobPositions
     {
         public string TitleEng { get; set; }
         public string TitleFre { get; set; }
-        public string DescriptionEng { get; set; }
-        public string DescriptionFre { get; set; }
+        public string PositionDescEng { get; set; }
+        public string PositionDescFre { get; set; }
     }
     public class PostJobPositionCommandValidator : AbstractCommandValidator<PostJobPositionCommandGetJobPositionIdQuery>
     {
@@ -22,9 +22,9 @@ namespace Business.Commands.Admin.JobPositions
                 .MaximumLength(3000);
             RuleFor(e => e.TitleFre)
                 .MaximumLength(3000);
-            RuleFor(b => b.DescriptionEng)
+            RuleFor(b => b.PositionDescEng)
                  .MaximumLength(8000);
-            RuleFor(b => b.DescriptionFre)
+            RuleFor(b => b.PositionDescFre)
                 .MaximumLength(8000);
         }
     }
@@ -43,8 +43,8 @@ namespace Business.Commands.Admin.JobPositions
             {
                 TitleEng = query.TitleEng,
                 TitleFre = query.TitleFre,
-                PositionDescEng = string.IsNullOrEmpty(query.DescriptionEng) ? "" : query.DescriptionEng,
-                PositionDescFre = string.IsNullOrEmpty(query.DescriptionFre) ? "" : query.DescriptionFre,
+                PositionDescEng = string.IsNullOrEmpty(query.PositionDescEng) ? "" : query.PositionDescEng,
+                PositionDescFre = string.IsNullOrEmpty(query.PositionDescFre) ? "" : query.PositionDescFre,
                 Active = 1
             };
             await _db.JobPositions.AddAsync(newjobposition, cancellationToken);

--- a/Business.Dtos/CustomValidationForDtos.cs
+++ b/Business.Dtos/CustomValidationForDtos.cs
@@ -3,29 +3,11 @@ using System.Collections.Generic;
 using System.Linq;
 using System.ComponentModel.DataAnnotations;
 using System.Text.RegularExpressions;
-using Business.Dtos.JobCompetencies;
-using DataModel.Services;
 
-namespace DataModel
+namespace Business.Dtos
 {
-    public class CustomValidation
+    public class CustomValidationForDtos
     {
-        public sealed class CheckOneRegionSelected : ValidationAttribute
-        {
-            protected override ValidationResult IsValid(object value, ValidationContext validationContext)
-            {
-                string errMsg = "Make sure that at least one region is selected";
-                if (value != null)
-                {
-                    List<string> valueList = (List<string>)value;
-                    if (valueList.Any())
-                    {
-                        return ValidationResult.Success;
-                    }
-                }
-                return new ValidationResult(errMsg);
-            }
-        }
 
         public sealed class BothOrNone : ValidationAttribute
         {

--- a/Business.Dtos/JobCompetencies/JobCertificateDto.cs
+++ b/Business.Dtos/JobCompetencies/JobCertificateDto.cs
@@ -4,6 +4,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using static Business.Dtos.CustomValidationForDtos;
 
 namespace Business.Dtos.JobCompetencies
 {
@@ -22,11 +23,17 @@ namespace Business.Dtos.JobCompetencies
 
         [Display(Name = "Description English")]
         [MaxLength(1000)]
+        [BothOrNone("DescFre", "Both descriptions must be provided if one is filled out")]
         public string DescEng { get; set; }
 
         [Display(Name = "Description French")]
         [MaxLength(1000)]
         public string DescFre { get; set; }
+
+        public string CertificateDescEng { get; set; }
+
+        public string CertificateDescFre { get; set; }
+
         public int Active { get; set; }
     }
 }

--- a/Business.Dtos/JobCompetencies/JobCompetencyDto.cs
+++ b/Business.Dtos/JobCompetencies/JobCompetencyDto.cs
@@ -20,25 +20,64 @@ namespace Business.Dtos.JobCompetencies
         public string TypeNameFre { get; set; }
 
         [Display(Name = "Name English")]
+        [MaxLength(1000)]
+        [Required]
         public string NameEng { get; set; }
 
         [Display(Name = "Name French")]
+        [MaxLength(1000)]
+        [Required]
         public string NameFre { get; set; }
 
         [Display(Name = "Description English")]
+        [MaxLength(2500)]
+        [Required]
         public string DescEng { get; set; }
 
         [Display(Name = "Description French")]
+        [MaxLength(2500)]
+        [Required]
         public string DescFre { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level1DescEng { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level1DescFre { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level2DescEng { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level2DescFre { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level3DescEng { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level3DescFre { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level4DescEng { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level4DescFre { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level5DescEng { get; set; }
+
+        [MaxLength(8000)]
+        [Required]
         public string Level5DescFre { get; set; }
+
     }
 }

--- a/Business.Queries/JobCertificates/GetAllJobCertificateDescriptionsQueryHandler.cs
+++ b/Business.Queries/JobCertificates/GetAllJobCertificateDescriptionsQueryHandler.cs
@@ -26,7 +26,9 @@ namespace Business.Queries.JobCertificates
                     Id = e.Id,
                     DescEng = e.DescEng,
                     DescFre = e.DescFre,
-                    Active = e.Active
+                    Active = e.Active,
+                    CertificateDescEng = e.DescEng,
+                    CertificateDescFre = e.DescFre
                 })
                 .ToListAsync(cancellationToken);
 

--- a/Business.Queries/JobCertificates/GetAllJobCertificatesQueryHandler.cs
+++ b/Business.Queries/JobCertificates/GetAllJobCertificatesQueryHandler.cs
@@ -28,7 +28,9 @@ namespace Business.Queries.JobCertificates
                     NameFre = e.NameFre,
                     DescEng = e.DescEng,
                     DescFre = e.DescFre,
-                    Active = e.Active
+                    Active = e.Active,
+                    CertificateDescEng = e.DescEng,
+                    CertificateDescFre = e.DescFre
                 })
                 .ToListAsync(cancellationToken);
 

--- a/Business.Queries/JobCertificates/GetJobCertificateByIdQueryHandler.cs
+++ b/Business.Queries/JobCertificates/GetJobCertificateByIdQueryHandler.cs
@@ -32,7 +32,9 @@ namespace Business.Queries.JobCertificates
                     NameFre = e.NameFre,
                     DescEng = e.DescEng,
                     DescFre = e.DescFre,
-                    Active = e.Active
+                    Active = e.Active,
+                    CertificateDescEng = e.DescEng,
+                    CertificateDescFre = e.DescFre,
 
                 }).FirstOrDefaultAsync(cancellationToken);
         }

--- a/Business.Queries/JobCompetencies/GetJobCompetencyByIdQueryHandler.cs
+++ b/Business.Queries/JobCompetencies/GetJobCompetencyByIdQueryHandler.cs
@@ -22,9 +22,9 @@ namespace Business.Queries.JobCompetencies
             _db = db;
         }
 
-        public Task<JobCompetencyDto> HandleAsync(GetJobCompetencyByIdQuery query, CancellationToken cancellationToken = new CancellationToken())
+        public async Task<JobCompetencyDto> HandleAsync(GetJobCompetencyByIdQuery query, CancellationToken cancellationToken = new CancellationToken())
         {
-            return _db.CompetencyTypeGroups.Where(e => e.CompetencyId == query.Id)
+            var comp = await _db.CompetencyTypeGroups.Where(e => e.CompetencyId == query.Id)
                 .Include(e => e.Competency)
                 .Select(e => new JobCompetencyDto()
                 {
@@ -37,8 +37,34 @@ namespace Business.Queries.JobCompetencies
                     DescFre = e.Competency.DescFre,
                     Active = e.Competency.Active,
                     TypeId = e.CompetencyTypeId
-
                 }).FirstOrDefaultAsync(cancellationToken);
+
+            var ratingsGroups = await _db.CompetencyRatingGroups.Where(x => x.CompetencyId == query.Id)
+                .OrderBy(x => x.CompetencyRatingLevelId).ToListAsync();
+
+            if (ratingsGroups.Count == 5)
+            {
+                var levelDescs = await _db.CompetencyLevelRequirements
+                    .Where(x => ratingsGroups.Select(x => x.CompetencyLevelRequirementId).ToList()
+                    .Contains(x.Id)).OrderBy(x => x.Id).ToListAsync();
+
+                comp.Level1DescEng = levelDescs.ElementAt(0).DescEng;
+                comp.Level1DescFre = levelDescs.ElementAt(0).DescFre;
+
+                comp.Level2DescEng = levelDescs.ElementAt(1).DescEng;
+                comp.Level2DescFre = levelDescs.ElementAt(1).DescFre;
+
+                comp.Level3DescEng = levelDescs.ElementAt(2).DescEng;
+                comp.Level3DescFre = levelDescs.ElementAt(2).DescFre;
+
+                comp.Level4DescEng = levelDescs.ElementAt(3).DescEng;
+                comp.Level4DescFre = levelDescs.ElementAt(3).DescFre;
+
+                comp.Level5DescEng = levelDescs.ElementAt(4).DescEng;
+                comp.Level5DescFre = levelDescs.ElementAt(4).DescFre;
+            }
+
+            return comp;
         }
     }
 }

--- a/Business.Queries/JobPositions/GetAllJobCertificatesByJobPositionIdQueryHandler.cs
+++ b/Business.Queries/JobPositions/GetAllJobCertificatesByJobPositionIdQueryHandler.cs
@@ -36,7 +36,9 @@ namespace Business.Queries.JobPositions
                         DescEng = e.CertificateDescription.DescEng,
                         DescFre = e.CertificateDescription.DescFre,
                         CertificateDescId = e.CertificateDescriptionId,
-                        Active = e.Certificate.Active
+                        Active = e.Certificate.Active,
+                        CertificateDescEng = e.Certificate.DescEng,
+                        CertificateDescFre = e.Certificate.DescFre
 
                     }).ToListAsync(cancellationToken);
             }

--- a/DataModel/Certificate.cs
+++ b/DataModel/Certificate.cs
@@ -5,7 +5,7 @@ using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Metadata.Builders;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-
+using static DataModel.CustomValidation;
 
 namespace DataModel
 {
@@ -24,6 +24,7 @@ namespace DataModel
 
         [Display(Name = "Description English")]
         [MaxLength(1000)]
+        [BothOrNone("DescFre", "Both descriptions must be provided if one is filled out")]
         public string DescEng { get; set; }
 
         [Display(Name = "Description French")]

--- a/DataModel/CertificateDescription.cs
+++ b/DataModel/CertificateDescription.cs
@@ -13,9 +13,13 @@ namespace DataModel
         public int Id { get; set; }
 
         [Display(Name = "Description English")]
+        [MaxLength(1000)]
+        [Required]
         public string DescEng { get; set; }
 
         [Display(Name = "Description French")]
+        [MaxLength(1000)]
+        [Required]
         public string DescFre { get; set; }
 
         public int Active { get; set; } // ex : 0 = certificate Description deleted, 1 = certificate Description active

--- a/DataModel/Competency.cs
+++ b/DataModel/Competency.cs
@@ -13,15 +13,19 @@ namespace DataModel
         public int Id { get; set; }
 
         [Display(Name = "Name English")]
+        [Required]
         public string NameEng { get; set; }
 
         [Display(Name = "Name French")]
+        [Required]
         public string NameFre { get; set; }
 
         [Display(Name = "Description English")]
+        [Required]
         public string DescEng { get; set; }
 
         [Display(Name = "Description French")]
+        [Required]
         public string DescFre { get; set; }
 
         public int Active { get; set; } // ex : 0 = competency deleted, 1 = competency active

--- a/DataModel/DataModel.csproj
+++ b/DataModel/DataModel.csproj
@@ -25,6 +25,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+		<ProjectReference Include="..\Business.Dtos\Business.Dtos.csproj" />
 		<ProjectReference Include="..\Core\Core.csproj" />
 	</ItemGroup>
 

--- a/DataModel/JobPosition.cs
+++ b/DataModel/JobPosition.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using static DataModel.CustomValidation;
 
 namespace DataModel
 {
@@ -11,15 +12,22 @@ namespace DataModel
         public int Id { get; set; }
 
         [Display(Name = "Title English")]
+        [MaxLength(3000)]
+        [Required(ErrorMessage = "The position title is required")]
         public string TitleEng { get; set; } // ex: Manager, IT advisor
 
         [Display(Name = "Title French")]
+        [MaxLength(3000)]
+        [Required(ErrorMessage = "The position title is required")]
         public string TitleFre { get; set; }
 
         [Display(Name = "Position Description English")]
+        [MaxLength(8000)]
+        [BothOrNone("PositionDescFre", "Both descriptions must be provided if one is filled out")]
         public string PositionDescEng { get; set; } // ex: Manage an engine room crew
 
         [Display(Name = "Position Description French")]
+        [MaxLength(8000)]
         public string PositionDescFre { get; set; }
 
         public int Active { get; set; } // ex : 0 = Position deleted, 1 = Position active

--- a/Service/Controllers/AdminController.cs
+++ b/Service/Controllers/AdminController.cs
@@ -22,7 +22,7 @@ namespace Service.Controllers
         }
 
         [HttpGet, Route("reseed")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
         public async Task<IActionResult> Reseed()
         {
             await _commandSender.ValidateAndSendAsync(new ReseedDataCommand(), ModelState);

--- a/Service/Controllers/JobCertificateController.cs
+++ b/Service/Controllers/JobCertificateController.cs
@@ -58,64 +58,55 @@ namespace Service.Controllers
             return Ok(results);
         }
 
-        [HttpGet, Route("addjobcertificate")]
+        [HttpPost, Route("addjobcertificate")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-        public async Task<IActionResult> AddJobCertificate(
-
-                [FromQuery] string nameEng,
-                [FromQuery] string nameFre,
-                [FromQuery] string descEng,
-                [FromQuery] string descFre)
+        public async Task<IActionResult> AddJobCertificate([FromBody] AddJobCertificateCommand query)
 
         {
-            var query = new AddJobCertificateCommand
-            {
-                NameEng = nameEng,
-                NameFre = nameFre,
-                DescEng = descEng,
-                DescFre = descFre,
-            };
-
             var results =
             await _queryProvider.ProcessAsync(query);
             return Ok(results);
         }
 
-        [HttpGet, Route("addjobcertificatedescription/{DescEng}/{DescFre}")]
+        [HttpPost, Route("addjobcertificatedescription")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-        public async Task<IActionResult> AddJobCertificate([FromRoute] AddJobCertificateDescriptionCommand query)
+        public async Task<IActionResult> AddJobCertificate([FromBody] AddJobCertificateDescriptionCommand query)
         {
             var results =
-                await _queryProvider.ProcessAsync(query);
-                   return Ok(results);
+            await _queryProvider.ProcessAsync(query);
+            return Ok(results);
         }
 
         [HttpPost, Route("deletejobcertificate")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task DeleteJobCertificate([FromBody] DeleteJobCertificateByIdCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> DeleteJobCertificate([FromBody] DeleteJobCertificateByIdCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("updatejobcertificate")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task UpdateJobCertificate([FromBody] UpdateJobCertificateCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateJobCertificate([FromBody] UpdateJobCertificateCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("updatejobcertificatedescription")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task UpdateJobCertificateDescription([FromBody] UpdateJobCertificateDescriptionCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateJobCertificateDescription([FromBody] UpdateJobCertificateDescriptionCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("deletejobcertificatedescription")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task DeleteJobCertificateDescription([FromBody] DeleteJobCertificateDescriptionByIdCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> DeleteJobCertificateDescription([FromBody] DeleteJobCertificateDescriptionByIdCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
     }
 }

--- a/Service/Controllers/JobCompetencyController.cs
+++ b/Service/Controllers/JobCompetencyController.cs
@@ -84,62 +84,29 @@ namespace Service.Controllers
             return Ok(results);
         }
 
-        [HttpGet, Route("addjobcompetency")]
+        [HttpPost, Route("addjobcompetency")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-        public async Task<IActionResult> AddJobCompetency(
-        [FromQuery] int typeId,
-        [FromQuery] string nameEng,
-        [FromQuery] string nameFre,
-        [FromQuery] string  descEng,
-        [FromQuery] string  descFre,
-        [FromQuery] string level1DescEng,
-        [FromQuery] string level1DescFre,
-        [FromQuery] string level2DescEng,
-        [FromQuery] string level2DescFre,
-        [FromQuery] string level3DescEng,
-        [FromQuery] string level3DescFre,
-        [FromQuery] string level4DescEng,
-        [FromQuery] string level4DescFre,
-        [FromQuery] string level5DescEng,
-        [FromQuery] string level5DescFre)
+        public async Task<IActionResult> AddJobCompetency([FromBody] AddJobCompetencyCommand query)
         {
-            var query = new AddJobCompetencyCommand
-            {
-                TypeId = typeId,
-                NameEng = nameEng,
-                NameFre = nameFre,
-                DescEng = descEng,
-                DescFre = descFre,
-                Level1DescEng = level1DescEng,
-                Level1DescFre = level1DescFre,
-                Level2DescEng = level2DescEng,
-                Level2DescFre = level2DescFre,
-                Level3DescEng = level3DescEng,
-                Level3DescFre = level3DescFre,
-                Level4DescEng = level4DescEng,
-                Level4DescFre = level4DescFre,
-                Level5DescEng = level5DescEng,
-                Level5DescFre = level5DescFre,
-
-            };
-
             var results =
             await _queryProvider.ProcessAsync(query);
             return Ok(results);
         }
 
         [HttpPost, Route("deletejobcompetency")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task DeleteJobCompetency([FromBody] DeleteJobCompetencyByIdCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> DeleteJobCompetency([FromBody] DeleteJobCompetencyByIdCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("updatejobcompetency")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task UpdateJobCompetency([FromBody] UpdateJobCompetencyCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateJobCompetency([FromBody] UpdateJobCompetencyCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
     }
 }

--- a/Service/Controllers/JobGroupController.cs
+++ b/Service/Controllers/JobGroupController.cs
@@ -106,10 +106,11 @@ namespace Service.Controllers
         }
 
         [HttpPost, Route("addjobgroupposition")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddJobCompetency([FromBody] AddJobGroupPositionCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddJobCompetency([FromBody] AddJobGroupPositionCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
     }
 }

--- a/Service/Controllers/JobPositionController.cs
+++ b/Service/Controllers/JobPositionController.cs
@@ -103,28 +103,17 @@ namespace Service.Controllers
         }
 
         [HttpPost, Route("addjobposition")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddJobCompetency([FromBody] AddJobPositionCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddJobCompetency([FromBody] AddJobPositionCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
-        [HttpGet, Route("addjobpositiongetid")]
+        [HttpPost, Route("addjobpositiongetid")]
         [ProducesResponseType(typeof(int), StatusCodes.Status200OK)]
-        public async Task<IActionResult> AddJobPositionGetId(
-            [FromQuery] string titleEng,
-            [FromQuery] string titleFre,
-            [FromQuery] string descriptionEng,
-            [FromQuery] string descriptionFre)
+        public async Task<IActionResult> AddJobPositionGetId([FromBody] PostJobPositionCommandGetJobPositionIdQuery query)
         {
-            var query = new PostJobPositionCommandGetJobPositionIdQuery
-            {
-                TitleEng = titleEng,
-                TitleFre = titleFre,
-                DescriptionEng = descriptionEng,
-                DescriptionFre = descriptionFre
-            };
-
             var results =
             await _queryProvider.ProcessAsync(query);
             return Ok(results);
@@ -140,24 +129,27 @@ namespace Service.Controllers
         }
 
         [HttpPost, Route("updatejobposition")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task UpdateJobCompetency([FromBody] UpdateJobPositionCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateJobCompetency([FromBody] UpdateJobPositionCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("addjobrolepositioncompetency")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddJobCompetency([FromBody] AddJobRolePositionCompetencyCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddJobCompetency([FromBody] AddJobRolePositionCompetencyCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("addjobrolepositioncertificate")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddJobCertificate([FromBody] AddJobRolePositionCertificateCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddJobCertificate([FromBody] AddJobRolePositionCertificateCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpGet, Route("getjobpositionid/{Title}")]
@@ -170,24 +162,27 @@ namespace Service.Controllers
         }
 
         [HttpPost, Route("addjobrolepositionlocation")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddJobCertificate([FromBody] AddJobRolePositionLocationsCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddJobCertificate([FromBody] AddJobRolePositionLocationsCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("addjobrolepositionhlcategory")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddJobCertificate([FromBody] AddJobRolePositionHLCategoryCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddJobCertificate([FromBody] AddJobRolePositionHLCategoryCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("deletejobposition")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task DeleteJobPosition([FromBody] DeleteJobPositionByIdCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> DeleteJobPosition([FromBody] DeleteJobPositionByIdCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpGet, Route("{Id}/hlcategoryId")]

--- a/Service/Controllers/SimilarController.cs
+++ b/Service/Controllers/SimilarController.cs
@@ -62,17 +62,19 @@ namespace Service.Controllers
             return Ok(results);
         }
         [HttpPost, Route("updatesimilarjobpositions")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task UpdateSimilarPositions([FromBody] UpdateSimilarPositionsCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> UpdateSimilarPositions([FromBody] UpdateSimilarPositionsCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpPost, Route("addsimilarjobpositions")]
-        [ProducesResponseType(typeof(void), StatusCodes.Status200OK)]
-        public async Task AddSimilarPositions([FromBody] AddSimilarPositionsCommand command)
+        [ProducesResponseType(typeof(Task<IActionResult>), StatusCodes.Status200OK)]
+        public async Task<IActionResult> AddSimilarPositions([FromBody] AddSimilarPositionsCommand command)
         {
             await _commandSender.ValidateAndSendAsync(command, ModelState);
+            return Ok();
         }
 
         [HttpGet, Route("hundredpercentsimilarjobpositions/{JobPositionId}")]


### PR DESCRIPTION
Full list of changes (unfortunately, there are a LOT):

**API Changes:**

- Changed all create commands from HTTP GET to POST. This avoids the query string character limits that could be encountered when creating items with very long names. Also, it's better design to create data with a post rather than a get. (These changes affect both the requests code and the controllers that handle the endpoints)

- Changed all of the controller endpoints that used to return void to now return a simple status 200 message (this does not change any functionality, but is a better practice)

- Changed the queries that were getting job certificates to add two properties to the results, which are used in the application if the certificate has its own description

- Changed the query that finds a single competency by id to include the competency level descriptions with it, instead of requiring further requests

**Data Models / Form Validation :**

 - Enforced the string limits on ALL form fields in the application (these were applied using data annotations in the data model classes themselves)

 - Made more fields required to ensure proper functionality (for example, creating a competency now requires ALL fields to be filled out)

 - Positions now require at least one competency when being created/edited
 
 - When creating/editing similar positions, at least one position must be added as similar

 - Removed the Thread.Sleep that would occur whenever a form was submitted, which means that the application runs as fast as it can, not limited by some sleep time

 - Made it so two elements of the same category can not have the exact same name (they also can't have the same name as an element which was deleted)

 - For descriptions in general, if one is provided, the other one is now needed as well
 
**Other Features:**

- Added support for certificate descriptions: if a certificate has a description, it will now display as an expandable element in position create/details/edit. The certificate description can also be seen in certificate details/delete. The descriptions support having line breaks in them, and they have a special markdown for adding links, which may come useful at some point. The certificate edit/create includes instructions on how to denote links properly

- Added a dropdown when hovering over the competencies link in the navigation, with four options, one for each of the competency types

- Added the ability to print any index page, and the content will be formatted nicely

- When creating a position, all behavioural competencies will already be added, since they apply to all positions (except executive ones, but that's a very rare case)

- Added navigation to locate/delete in all detail pages (note: the Locate feature is not available yet for all items, despite the links being included in the index pages. That feature will be in its own PR)

- Now, whenever a form is submitted, all of its text fields will be trimmed using `string.trim()`, which will remove unnecessary whitespace

**Small Fixes:**

 - The position create/edit page models have been optimized to avoid massive code duplication. This was also done in the similar positions create/edit page models

 - Styling changes

 - When changing pages, the main table (if applicable) should have its height set on page load, which removes a small flicker

 - More javascript changes, some of which will apply to the locate elements PR (the next one)

 - Fixed an issue that caused executive competencies added to a position to have their level descriptions use "director" levels in the user-side tool. As it is currently, the admin tool will display any executive competency level descriptions using the director levels, but the user-side tool still uses the regular novice through expert levels