### PR TITLE
Added feature to locate certificates and competencies

### DIFF
--- a/Admin/Pages/Certificates/Descriptions/Create.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Create.cshtml.cs
@@ -50,7 +50,7 @@ namespace Admin.Pages.Certificates.Descriptions
                     }
                     else if (inactiveDescs.Select(x => x.DescEng.ToLowerInvariant()).Contains(desc.DescEng.ToLowerInvariant()))
                     {
-                        return "There English certificate description already exists, but it was deleted. " +
+                        return "That English certificate description already exists, but it was deleted. " +
                             "If you wish to enable it once again, contact technical support";
                     }
                 }

--- a/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Edit.cshtml.cs
@@ -50,7 +50,7 @@ namespace Admin.Pages.Certificates.Descriptions
                     }
                     else if (inactiveDescs.Select(x => x.DescEng.ToLowerInvariant()).Contains(desc.DescEng.ToLowerInvariant()))
                     {
-                        return "There English certificate description already exists, but it was deleted. " +
+                        return "That English certificate description already exists, but it was deleted. " +
                             "If you wish to enable it once again, contact technical support";
                     }
                 }

--- a/Admin/Pages/Certificates/Descriptions/Locate.cshtml
+++ b/Admin/Pages/Certificates/Descriptions/Locate.cshtml
@@ -1,0 +1,234 @@
+﻿@page
+@model Admin.Pages.Certificates.Descriptions.LocateModel
+@using Business.Dtos.JobPositions
+@using Business.Dtos.JobCompetencies
+@{
+    ViewData["Title"] = "Locate Certificate Descriptions";
+
+    bool addedInOnePlace = false;
+
+    if (Model.LocatingADescription)
+    {
+        addedInOnePlace = (Model.PositionsThatHaveTheCertificateDesc.Any());
+    }
+
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.Descriptions.Where(e => (Model.Filter == null
+            || e.DescEng.ToLower().Contains(Model.Filter.ToLower())
+            || e.DescFre.ToLower().Contains(Model.Filter.ToLower()))
+            && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.DescEng.ToLower()).ToList();
+    var itemsList = itemsThatMatchFilter.ToList();
+}
+
+<div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
+    @if (!Model.LocatingADescription)
+    {
+        <h1>Locate Certificate Descriptions</h1>
+
+        <form>
+            <div class="form-actions no-color">
+                <h6>
+                    <label for="Filter">Find certificate descriptions:</label>
+                    <input type="text" asp-for="@Model.Filter" />
+                    <input type="submit" value="Search" class="btn btn-primary" /> 
+                    @if (!String.IsNullOrWhiteSpace(Model.Filter))
+                    {
+                        <span><span class="vertical-bar">|</span> <a asp-page="./Locate">Back to Full List</a></span>
+                    }
+
+                    <a class="btn btn-secondary pull-right bottom-two-px bold index-right-button" asp-page="Index">Back to List</a>
+                </h6>
+            </div>
+        </form>
+    }
+    else
+    {
+        bool emptyDesc = Model.DescriptionBeingLocated.Id == 1;
+
+        <h4 class="small-margin-bottom">Located Certificate Description: 
+                @if (emptyDesc)
+                {
+                    <span>*Empty Description*</span>
+                }
+                else
+                {
+                    <a target="_blank" href="/Certificates/Descriptions/Details?id=@Model.DescriptionBeingLocated.Id" class="print-link">
+                        @Model.DescriptionBeingLocated.DescEng <span class="text-dark">/</span> @Model.DescriptionBeingLocated.DescFre
+                        <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                    </a>
+                }
+                <span class="@(emptyDesc ? "" : "besides-external-link")">(@Model.PositionsThatHaveTheCertificateDesc.Count() 
+                    Result@(Model.PositionsThatHaveTheCertificateDesc.Count() > 1 ? "s" : ""))</span>
+        </h4>
+
+        <div class="space-btns no-margin-right small-margin-bottom large-margin-top no-padding-right container hide-in-print">
+            <div class="row no-margin-right">
+                <div class="col text-right no-margin-right no-padding @(addedInOnePlace ? "raise-elements-slightly" : "")" style="max-height: 38px">
+                    @if (addedInOnePlace)
+                    {
+                        <h6 class="glyphicon glyphicon-save-file display-inline position-relative locate-page-save-icon" onclick="print()"></h6>
+                    }
+                    <h6 class="display-inline"><a class="btn btn-primary bold bottom-two-px" href="/Certificates/Descriptions/Locate">Locate Another Description</a></h6>
+                    <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" asp-page="Index">Back to List</a>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@if (!Model.LocatingADescription)
+{
+    @if (itemsThatMatchFilter.Any())
+    {
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
+            <table class="table">
+                <thead>
+                    <tr class="table-header-row text-center">
+                        <th class="col-5"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate Description English</b></th>
+                        <th class="col-5"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate Description French</b></th>
+                        <th class="col-2">
+                            <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop"
+                            aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in itemsList)
+                    {
+
+                        <tr>
+                            @if (item.Id != 1)
+                            {
+                                <td>
+                                    @item.DescEng
+                                </td>
+                                <td>
+                                    @item.DescFre
+                                </td>
+                            }
+                            else
+                            {
+                                <td class="text-center">
+                                    <b>*Empty Descrpition*</b>
+                                </td>
+                                <td class="text-center">
+                                    <b>*Empty Descrpition*</b>
+                                </td>
+                            }
+                             <td class="text-center">
+                                <a href="/Certificates/Descriptions/Locate?id=@item.Id" class="load-link">Locate</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        if (!string.IsNullOrWhiteSpace(Model.Filter))
+        {
+            <h4 class="no-results">No certificate descriptions match the filter "@Model.Filter"</h4>
+        }
+        else
+        {
+            <h4 class="no-results">There are currently no certificate descriptions</h4>
+        }
+    }
+}
+else 
+{
+    if (addedInOnePlace) 
+    {
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
+            <table class="table">
+                <thead>
+                   <tr class="table-header-row text-center">
+                        <th style="width: 10%"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                        <th style="width: 20%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                        <th style="width: 20%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
+                        <th style="width: 35%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificates with that Description</b></th>
+                        <th style="width: 15%">
+                            <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
+                            aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+
+                    @{
+                        var positions = Model.PositionsThatHaveTheCertificateDesc.OrderBy(x => x.Key.JobTitleEng.ToLower()).OrderBy(x => x.Key.LevelCode.ToLower()).ToList();
+                    }
+
+                    @foreach (var pos in positions)
+                    {
+                        <tr>                                
+                            <td class="text-center">
+                                @pos.Key.LevelCode
+                            </td>
+                            <td>
+                                @pos.Key.JobTitleEng
+                            </td>
+                            <td>
+                                @pos.Key.JobTitleFre
+                            </td>
+                            @{
+                                var certs = pos.Value;
+                                certs = certs.OrderBy(x => x.NameEng.ToLower()).ToList();
+                            }
+                            <td>
+                                @for (int i = 0; i < certs.Count(); i++) 
+                                {
+                                    var cert = certs.ElementAt(i);
+                                    <a href="/Certificates/Details?id=@cert.Id" target="_blank" class="rememberIfVisited print-link">
+                                        @cert.NameEng <b>/</b> @cert.NameFre
+                                        <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                    </a>
+
+                                    if (i < certs.Count() - 1)
+                                    {
+                                        <br />
+                                        <br />
+                                    }
+                                }
+                            </td>
+
+                            @{
+                                string scrollTargetSpecific = "";
+
+                                if (certs.Count() == 1)
+                                {
+                                    scrollTargetSpecific = "certificateScroll-" + certs.ElementAt(0).Id.ToString() + "_c_h_o";
+                                } 
+                            }
+
+                            <td class="text-center">
+                                <a href="/Positions/Details?positionid=@pos.Key.JobTitleId&scrollTo=@(certs.Count() == 1 ? scrollTargetSpecific : "certificatesRow_h")" target="_blank" class="rememberIfVisited print-link print-underline">Details</a><span class="hide-in-print"> | </span>
+                                <a href="/Positions/Edit?id=@pos.Key.JobTitleId&scrollTo=@(certs.Count() == 1 ? scrollTargetSpecific : "certTableHeader_h")" target="_blank" class="rememberIfVisited hide-in-print">
+                                    Edit
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else 
+    {
+        <h4 class="no-results">This certificate description has not been added to any certificates</h4>
+    }
+}

--- a/Admin/Pages/Certificates/Descriptions/Locate.cshtml.cs
+++ b/Admin/Pages/Certificates/Descriptions/Locate.cshtml.cs
@@ -1,0 +1,121 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Admin.Data;
+using Business.Dtos.JobPositions;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using DataModel;
+using Microsoft.AspNetCore.Http;
+using Business.Dtos.JobCompetencies;
+
+namespace Admin.Pages.Certificates.Descriptions
+{
+    public class LocateModel : PageModel
+    {
+        private readonly DataModel.CctDbContext _context;
+
+        private readonly JobPositionService _jobPositionService;
+        private readonly JobCompetencyService _jobCompetencyService;
+        private readonly JobCertificateService _jobCertificateService;
+
+        public LocateModel(DataModel.CctDbContext context, JobPositionService jobPositionService, JobCompetencyService jobCompetencyService, JobCertificateService jobCertificateService)
+        {
+            _context = context;
+            _jobPositionService = jobPositionService;
+            _jobCompetencyService = jobCompetencyService;
+            _jobCertificateService = jobCertificateService;
+        }
+        [BindProperty(SupportsGet = true)]
+        public string Filter { get; set; }
+        public IList<JobCertificateDto> Descriptions { get; set; }
+
+        public bool DisplayTopOfPage { get; set; }
+
+        public bool LocatingADescription { get; set; } = false;
+
+        public double LastTableContainerHeight { get; set; } = 300;
+
+        public CertificateDescription DescriptionBeingLocated { get; set; }
+
+        public Dictionary<JobPositionDto, List<JobCertificateDto>> PositionsThatHaveTheCertificateDesc { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            DisplayTopOfPage = true;
+            var sessionStr = HttpContext.Session.GetString("displayTopOfPage");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (sessionStr.ToLower() == "false")
+                {
+                    DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
+                }
+            }
+
+            Descriptions = await _jobCertificateService.GetAllJobCertificateDescriptions();
+
+            if (id != null)
+            {
+                try
+                {
+                    DescriptionBeingLocated = await _context.CertificateDescriptions.FindAsync(id.Value);
+                }
+                catch
+                {
+                    DescriptionBeingLocated = null;
+                }
+
+                if (DescriptionBeingLocated != null)
+                {
+                    if (DescriptionBeingLocated.Active == 1)
+                    {
+                        LocatingADescription = true;
+                    }
+                }
+            }
+
+            if (LocatingADescription)
+            {
+                var activePositions = (await _jobPositionService.GetAllJobPositions()).Where(x => x.Active == 1).ToList();
+                int idToFind = id.Value;
+
+                PositionsThatHaveTheCertificateDesc = new Dictionary<JobPositionDto, List<JobCertificateDto>>();
+
+                foreach (var pos in activePositions)
+                {
+                    var positionCerts = await _jobCompetencyService.GetJobCertificatesById(pos.JobTitleId);
+                    var certsWithMatchingDesc = new List<JobCertificateDto>();
+
+                    foreach (var cert in positionCerts)
+                    {
+                        if (cert.Active == 1)
+                        {
+                            if (cert.CertificateDescId == idToFind)
+                            {
+                                certsWithMatchingDesc.Add(cert);
+                            }
+                        }
+                    }
+                    if (certsWithMatchingDesc.Any())
+                    {
+                        PositionsThatHaveTheCertificateDesc.Add(pos, certsWithMatchingDesc);
+                    }
+                }
+            }
+
+            return Page();
+        }
+    }
+}

--- a/Admin/Pages/Certificates/Locate.cshtml
+++ b/Admin/Pages/Certificates/Locate.cshtml
@@ -1,0 +1,198 @@
+﻿@page
+@model Admin.Pages.Certificates.LocateModel
+@using Business.Dtos.JobPositions
+@{
+    ViewData["Title"] = "Locate Certificates";
+
+    bool addedInOnePlace = false;
+
+    if (Model.LocatingACertificate)
+    {
+        addedInOnePlace = (Model.PositionsThatHaveTheCertificate.Any());
+    }
+
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.Certificates.Where(e => (Model.Filter == null 
+            || e.NameEng.ToLower().Contains(Model.Filter.ToLower()) 
+            || e.NameFre.ToLower().Contains(Model.Filter.ToLower()))
+            && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.NameEng.ToLower()).ToList();
+    var itemsList = itemsThatMatchFilter.ToList();
+}
+
+<div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
+    @if (!Model.LocatingACertificate)
+    {
+        <h1>Locate Certificates</h1>
+
+        <form>
+            <div class="form-actions no-color">
+                <h6>
+                    <label for="Filter">Find certificates:</label>
+                    <input type="text" asp-for="@Model.Filter" />
+                    <input type="submit" value="Search" class="btn btn-primary" /> 
+                    @if (!String.IsNullOrWhiteSpace(Model.Filter))
+                    {
+                        <span><span class="vertical-bar">|</span> <a asp-page="./Locate">Back to Full List</a></span>
+                    }
+
+                    <a class="btn btn-secondary pull-right bottom-two-px bold index-right-button" asp-page="Index">Back to List</a>
+                </h6>
+            </div>
+        </form>
+    }
+    else
+    {
+        <h4 class="small-margin-bottom">Located Certificate: 
+            <a target="_blank" href="/Certificates/Details?id=@Model.CertificateBeingLocated.Id" class="print-link">
+                @Model.CertificateBeingLocated.NameEng <span class="text-dark">/</span> @Model.CertificateBeingLocated.NameFre
+                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+            </a>
+            <span class="besides-external-link">(@Model.PositionsThatHaveTheCertificate.Count() 
+                Result@(Model.PositionsThatHaveTheCertificate.Count() > 1 ? "s" : ""))</span>
+        </h4>
+
+        <div class="space-btns no-margin-right small-margin-bottom large-margin-top no-padding-right container hide-in-print">
+            <div class="row no-margin-right">
+                <div class="col text-right no-margin-right no-padding @(addedInOnePlace ? "raise-elements-slightly" : "")" style="max-height: 38px">
+                    @if (addedInOnePlace)
+                    {
+                        <h6 class="glyphicon glyphicon-save-file display-inline position-relative locate-page-save-icon" onclick="print()"></h6>
+                    }
+                    <h6 class="display-inline"><a class="btn btn-primary bold bottom-two-px" href="/Certificates/Locate">Locate Another Certificate</a></h6>
+                    <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" asp-page="Index">Back to List</a>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@if (!Model.LocatingACertificate)
+{
+    @if (itemsThatMatchFilter.Any())
+    {
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
+            <table class="table">
+                <thead>
+                    <tr class="table-header-row text-center">
+                        <th class="col-5"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Certificate English</b></th>
+                        <th class="col-5"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Certificate French</b></th>
+                        <th class="col-2">
+                            <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
+                            aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in itemsList)
+                    {
+                        <tr>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.NameEng)
+                            </td>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.NameFre)
+                            </td>
+                             <td class="text-center">
+                                <a href="/Certificates/Locate?id=@item.Id" class="load-link">Locate</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        if (!string.IsNullOrWhiteSpace(Model.Filter))
+        {
+            <h4 class="no-results">No certificates match the filter "@Model.Filter"</h4>
+        }
+        else
+        {
+            <h4 class="no-results">There are currently no certificates</h4>
+        }
+    }
+}
+else 
+{
+    if (addedInOnePlace) 
+    {
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
+            <table class="table">
+                <thead>
+                   <tr class="table-header-row text-center">
+                        <th style="width: 10%"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                        <th style="width: 20%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                        <th style="width: 20%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
+                        <th style="width: 35%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Selected Certificate Description</b></th>
+                        <th style="width: 15%">
+                            <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
+                            aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+
+                    @{
+                        var positions = Model.PositionsThatHaveTheCertificate.OrderBy(x => x.Key.JobTitleEng.ToLower()).OrderBy(x => x.Key.LevelCode.ToLower()).ToList();
+                    }
+
+                    @foreach (var pos in positions)
+                    {
+                        <tr>                                
+                            <td class="text-center">
+                                @pos.Key.LevelCode
+                            </td>
+                            <td>
+                                @pos.Key.JobTitleEng
+                            </td>
+                            <td>
+                                @pos.Key.JobTitleFre
+                            </td>
+                            @{
+                                var cert = pos.Value;
+                                bool selectedACertDesc = !string.IsNullOrWhiteSpace(cert.DescEng) && !string.IsNullOrWhiteSpace(cert.DescFre);
+                            }
+                            <td>
+                                @if (selectedACertDesc)
+                                {
+                                    <a href="/Certificates/Descriptions/Details?id=@cert.CertificateDescId" target="_blank" class="rememberIfVisited print-link">
+                                        @cert.DescEng <b>/</b> @cert.DescFre
+                                        <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+                                    </a>
+                                }
+                                else
+                                {
+                                   <b>No description selected</b> 
+                                }
+                            </td>
+                            <td class="text-center">
+                                <a href="/Positions/Details?positionid=@pos.Key.JobTitleId&scrollTo=certificateScroll-@(cert.Id)_c_h" target="_blank" class="rememberIfVisited print-link print-underline">Details</a><span class="hide-in-print"> | </span>
+                                <a href="/Positions/Edit?id=@pos.Key.JobTitleId&scrollTo=certificateScroll-@(cert.Id)_c_h" target="_blank" class="rememberIfVisited hide-in-print">
+                                    Edit
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else 
+    {
+        <h4 class="no-results">This certificate has not been added to any positions</h4>
+    }
+}

--- a/Admin/Pages/Certificates/Locate.cshtml.cs
+++ b/Admin/Pages/Certificates/Locate.cshtml.cs
@@ -1,0 +1,120 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Admin.Data;
+using Business.Dtos.JobPositions;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using DataModel;
+using Microsoft.AspNetCore.Http;
+using Business.Dtos.JobCompetencies;
+
+namespace Admin.Pages.Certificates
+{
+    public class LocateModel : PageModel
+    {
+        private readonly DataModel.CctDbContext _context;
+
+        private readonly JobPositionService _jobPositionService;
+        private readonly JobCompetencyService _jobCompetencyService;
+
+        public LocateModel(DataModel.CctDbContext context, JobPositionService jobPositionService, JobCompetencyService jobCompetencyService)
+        {
+            _context = context;
+            _jobPositionService = jobPositionService;
+            _jobCompetencyService = jobCompetencyService;
+        }
+        [BindProperty(SupportsGet = true)]
+        public string Filter { get; set; }
+        public IList<JobCertificateDto> Certificates { get; set; }
+
+        public bool DisplayTopOfPage { get; set; }
+
+        public double LastTableContainerHeight { get; set; } = 300;
+
+        public bool LocatingACertificate { get; set; } = false;
+
+        public JobCertificateDto CertificateBeingLocated { get; set; }
+
+        public Dictionary<JobPositionDto, JobCertificateDto> PositionsThatHaveTheCertificate { get; set; }
+
+        public async Task<IActionResult> OnGetAsync(int? id)
+        {
+            DisplayTopOfPage = true;
+            var sessionStr = HttpContext.Session.GetString("displayTopOfPage");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (sessionStr.ToLower() == "false")
+                {
+                    DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
+                }
+            }
+
+            Certificates = await _jobCompetencyService.GetJobCertificates();
+
+            if (id != null)
+            {
+                try
+                {
+                    CertificateBeingLocated = await _jobCompetencyService.GetJobCertificateById(id.Value);
+                }
+                catch
+                {
+                    CertificateBeingLocated = null;
+                }
+
+                if (CertificateBeingLocated != null)
+                {
+                    if (CertificateBeingLocated.Active == 1)
+                    {
+                        LocatingACertificate = true;
+                    }
+                }
+            }
+
+            if (LocatingACertificate)
+            {
+                var activePositions = (await _jobPositionService.GetAllJobPositions()).Where(x => x.Active == 1).ToList();
+                int idToFind = id.Value;
+
+                PositionsThatHaveTheCertificate = new Dictionary<JobPositionDto, JobCertificateDto>();
+
+                var activeCertDescIds = await _context.CertificateDescriptions.Where(x => x.Active == 1).Select(x => x.Id).ToListAsync();
+
+                foreach (var pos in activePositions)
+                {
+                    var positionCerts = await _jobCompetencyService.GetJobCertificatesById(pos.JobTitleId);
+
+                    foreach (var cert in positionCerts)
+                    {
+                        if (cert.Id == idToFind)
+                        {
+                            if (!activeCertDescIds.Contains(cert.CertificateDescId))
+                            {
+                                cert.DescFre = "";
+                                cert.DescEng = "";
+                            }
+                            PositionsThatHaveTheCertificate.Add(pos, cert);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return Page();
+        }
+
+    }
+}

--- a/Admin/Pages/Competencies/Locate.cshtml
+++ b/Admin/Pages/Competencies/Locate.cshtml
@@ -1,0 +1,234 @@
+﻿@page
+@model Admin.Pages.Competencies.LocateModel
+@using Business.Dtos.JobPositions
+@{
+    ViewData["Title"] = "Locate Competencies";
+
+    bool addedInOnePlace = false;
+
+    if (Model.LocatingACompetency)
+    {
+        addedInOnePlace = (Model.PositionsThatHaveTheCompetency.Any());
+    }
+
+    bool maintainFilter = false;
+    string typeid = Model.Type.Id.ToString();
+    string classSelectedComp = "btn-info", classUnselectedComp = "btn-secondary";
+
+    var filterdata = new Dictionary<string, string>
+    {
+            {"typeid", typeid },
+            {"filter", Model.Filter }
+    };
+
+    string? filterValue = Model.Filter;
+    if (filterValue != null)
+    {
+        filterValue = filterValue.Trim();
+    }
+
+    var itemsThatMatchFilter = Model.Competencies.Where(e => (Model.Filter == null
+        || e.NameEng.ToLower().Contains(Model.Filter.ToLower())
+        || e.NameFre.ToLower().Contains(Model.Filter.ToLower()))
+        && (e.Active == 1));
+
+    itemsThatMatchFilter = itemsThatMatchFilter.OrderBy(x => x.NameEng.ToLower()).ToList();
+    var itemsList = itemsThatMatchFilter.ToList();
+}
+
+<div class="collapse @(Model.DisplayTopOfPage ? "show" : "")" id="collapsibleTop" aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")">
+    @if (!Model.LocatingACompetency)
+    {
+        <h1>Locate @Model.Type.NameEng</h1>
+
+        <p class="space-btns hide-in-print overflow-y-auto">
+            <a href="@("/Competencies/Locate?typeid=4" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right index-right-button @(typeid == "4" ? classSelectedComp : classUnselectedComp)">Executive</a>
+            <a href="@("/Competencies/Locate?typeid=3" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "3" ? classSelectedComp : classUnselectedComp)">Behavioural</a>
+            <a href="@("/Competencies/Locate?typeid=2" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "2" ? classSelectedComp : classUnselectedComp)">Technical</a>
+            <a href="@("/Competencies/Locate?typeid=1" + (maintainFilter ? "&filter=" + filterValue : ""))" class="btn pull-right @(typeid == "1" ? classSelectedComp : classUnselectedComp)">Knowledge</a>
+        </p>
+
+        <form method="post" class="hide-in-print">
+            <div class="form-actions no-color">
+                <h6>
+                    <label for="Filter">Find competencies:</label>
+                    <input type="text" asp-for="@Model.Filter"/>
+                    <input type="submit" value="Search" class="btn btn-primary" asp-all-route-data="@filterdata" /> 
+                    @if (!String.IsNullOrWhiteSpace(Model.Filter))
+                    {
+                        <span><span class="vertical-bar">|</span> <a href="/Competencies/Locate?typeid=@typeid">Back to Full List</a></span>
+                    }
+
+                    <a class="pull-right index-right-button" href="/Competencies/List?typeid=@typeid">Back to List</a>
+                </h6>
+            </div>
+        </form>
+    }
+    else
+    {
+        string compTypeName = Model.Type.NameEng;
+        if (compTypeName.Contains("cies"))
+        {
+            compTypeName = compTypeName.Replace("ies", "y");
+        }
+        else
+        {
+            compTypeName = compTypeName[..^1];
+        }
+
+        <h4 class="small-margin-bottom">Located @compTypeName: 
+            <a target="_blank" href="/Competencies/Details?id=@Model.CompetencyBeingLocated.Id" class="print-link">
+                @Model.CompetencyBeingLocated.NameEng <span class="text-dark">/</span> @Model.CompetencyBeingLocated.NameFre
+                <img src="~/images/icons/external_link_icon.png" class="external-link" alt="Open link in new tab" />
+            </a>
+            <span class="besides-external-link">(@Model.PositionsThatHaveTheCompetency.Count() 
+                Result@(Model.PositionsThatHaveTheCompetency.Count() > 1 ? "s" : ""))</span>
+        </h4>
+
+        <div class="space-btns no-margin-right small-margin-bottom large-margin-top no-padding-right container hide-in-print">
+            <div class="row no-margin-right">
+                <div class="col text-right no-margin-right no-padding @(addedInOnePlace ? "raise-elements-slightly" : "")" style="max-height: 38px">
+                    @if (addedInOnePlace)
+                    {
+                        <h6 class="glyphicon glyphicon-save-file display-inline position-relative locate-page-save-icon" onclick="print()"></h6>
+                    }
+                    <h6 class="display-inline"><a class="btn btn-primary bold bottom-two-px" href="/Competencies/Locate?typeid=@Model.CompetencyBeingLocated.TypeId">Locate Another Competency</a></h6>
+                    <a class="btn btn-secondary bottom-two-px bold no-margin-right right-button-locate" href="/Competencies/List?typeid=@Model.CompetencyBeingLocated.TypeId">Back to List</a>
+                </div>
+            </div>
+        </div>
+    }
+</div>
+
+@if (!Model.LocatingACompetency)
+{
+    @if (itemsThatMatchFilter.Any())
+    {
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
+            <table class="table">
+                <thead>
+                    <tr class="table-header-row text-center">
+                        <th class="col-2"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Competency English</b></th>
+                        <th class="col-2"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Competency French</b></th>
+                        <th class="col-3"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Description English</b></th>
+                        <th class="col-4"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Description French</b></th>
+                        <th class="col-1">
+                            <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
+                            aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+                    @foreach (var item in itemsList)
+                    {
+                        <tr>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.NameEng)
+                            </td>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.NameFre)
+                            </td>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.DescEng)
+                            </td>
+                            <td>
+                                @Html.DisplayFor(modelItem => item.DescFre)
+                            </td>
+                            <td class="text-center hide-in-print">
+                                <a asp-page="./Locate" asp-route-id="@item.Id" class="load-link">Locate</a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else
+    {
+        if (!string.IsNullOrWhiteSpace(Model.Filter))
+        {
+            <h4 class="no-results">No @Model.Type.NameEng.ToLower() match the filter "@Model.Filter"</h4>
+        }
+        else
+        {
+            <h4 class="no-results">There are currently no @Model.Type.NameEng.ToLower()</h4>
+        }
+    }
+}
+else 
+{
+    if (addedInOnePlace) 
+    {
+        <div id="table-container" style="max-height: @(Model.LastTableContainerHeight)px; height: @(Model.LastTableContainerHeight)px">
+            <table class="table">
+                <thead>
+                   <tr class="table-header-row text-center">
+                        <th style="width: 10%"><b class="sort-column sorted" data-toggle="tooltip" title="Click to sort column">Level</b></th>
+                        <th style="width: 25%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title English</b></th>
+                        <th style="width: 25%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Title French</b></th>
+                        <th style="width: 25%"><b class="sort-column" data-toggle="tooltip" title="Click to sort column">Competency Level</b></th>
+                        <th style="width: 15%">
+                            <img src="@(Model.DisplayTopOfPage ? "/images/icons/up_arrow.png" : "/images/icons/down_arrow.png")" 
+                            class="arrow-icon hide-in-print" data-toggle="collapse" data-target="#collapsibleTop" 
+                            aria-expanded="@(Model.DisplayTopOfPage ? "true" : "false")" aria-controls="collapsibleTop" 
+                            alt="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" tooltip
+                            title="@(Model.DisplayTopOfPage ? "Collapse" : "Expand") the top of the page" />
+                        </th>
+                    </tr>
+                </thead>
+                <tbody>
+
+                    @{
+                        var positions = Model.PositionsThatHaveTheCompetency.OrderBy(x => x.Key.JobTitleEng.ToLower()).OrderBy(x => x.Key.LevelCode.ToLower()).ToList();
+                    }
+
+                    @foreach (var pos in positions)
+                    {
+                        <tr>                                
+                            <td class="text-center">
+                                @pos.Key.LevelCode
+                            </td>
+                            <td>
+                                @pos.Key.JobTitleEng
+                            </td>
+                            <td>
+                                @pos.Key.JobTitleFre
+                            </td>
+                            @{
+                                var comp = pos.Value;
+                                var matchingLevel = Model.RatingLevels.Where(x => x.Id == comp.CompetencyRatingLevelId).FirstOrDefault();
+                                if (comp.TypeId == 4 && matchingLevel.Id <= 5) 
+                                {
+                                    matchingLevel = Model.RatingLevels.Where(x => x.Id == comp.CompetencyRatingLevelId + 5).FirstOrDefault();
+                                }
+                            }
+                            <td>
+                                @if (matchingLevel.NameEng.ToLowerInvariant() == matchingLevel.NameFre.ToLowerInvariant())
+                                {
+                                    <span><b>@matchingLevel.Value</b> - @matchingLevel.NameEng</span>
+                                }
+                                else
+                                {
+                                    <span><b>@matchingLevel.Value</b> - @matchingLevel.NameEng / @matchingLevel.NameFre</span>
+                                }
+                            </td>
+                            <td class="text-center">
+                                <a href="/Positions/Details?positionid=@pos.Key.JobTitleId&scrollTo=competencyScroll-@(comp.CompetencyId)_c_h" target="_blank" class="rememberIfVisited print-link print-underline">Details</a><span class="hide-in-print"> | </span>
+                                <a href="/Positions/Edit?id=@pos.Key.JobTitleId&scrollTo=competencyScroll-@(comp.CompetencyId)_c_h" target="_blank" class="rememberIfVisited hide-in-print">
+                                    Edit
+                                </a>
+                            </td>
+                        </tr>
+                    }
+                </tbody>
+            </table>
+        </div>
+    }
+    else 
+    {
+        <h4 class="no-results">This competency has not been added to any positions</h4>
+    }
+}

--- a/Admin/Pages/Competencies/Locate.cshtml.cs
+++ b/Admin/Pages/Competencies/Locate.cshtml.cs
@@ -1,0 +1,165 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Admin.Data;
+using Business.Dtos.JobPositions;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using DataModel;
+using Microsoft.AspNetCore.Http;
+using Business.Dtos.JobCompetencies;
+
+namespace Admin.Pages.Competencies
+{
+    public class LocateModel : PageModel
+    {
+        private readonly DataModel.CctDbContext _context;
+
+        private readonly JobPositionService _jobPositionService;
+        private readonly JobCompetencyService _jobCompetencyService;
+
+        public LocateModel(DataModel.CctDbContext context, JobPositionService jobPositionService, JobCompetencyService jobCompetencyService)
+        {
+            _context = context;
+            _jobPositionService = jobPositionService;
+            _jobCompetencyService = jobCompetencyService;
+        }
+        [BindProperty(SupportsGet = true)]
+        public string Filter { get; set; }
+        public JobCompetencyDto[] Competencies { get; set; }
+        public JobCompetencyTypeDto Type { get; set; }
+
+        public bool DisplayTopOfPage { get; set; }
+
+        public double LastTableContainerHeight { get; set; } = 300;
+
+        public bool LocatingACompetency { get; set; } = false;
+
+        public JobCompetencyDto CompetencyBeingLocated { get; set; }
+
+        public List<CompetencyRatingLevel> RatingLevels { get; set; }
+
+        public Dictionary<JobPositionDto, JobCompetencyRatingDto> PositionsThatHaveTheCompetency { get; set; }
+
+        private async Task PrepareNonLocatePage(int typeId)
+        {
+            var accepetedTypeIds = _context.CompetencyTypes.Select(c => c.Id).ToList();
+
+            if (!accepetedTypeIds.Contains(typeId))
+            {
+                Type = await _jobCompetencyService.GetJobCompetencyTypeById(1);
+                Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(1);
+            }
+            else
+            {
+                Type = await _jobCompetencyService.GetJobCompetencyTypeById(typeId);
+                Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(typeId);
+            }
+
+            DisplayTopOfPage = true;
+            var sessionStr = HttpContext.Session.GetString("displayTopOfPage");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (sessionStr.ToLower() == "false")
+                {
+                    DisplayTopOfPage = false;
+                }
+            }
+            sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+            if (!string.IsNullOrEmpty(sessionStr))
+            {
+                if (double.TryParse(sessionStr, out double num))
+                {
+                    if (num > 300)
+                    {
+                        LastTableContainerHeight = num;
+                    }
+                }
+            }
+        }
+
+        public async Task<IActionResult> OnGetAsync(int? id, int typeId)
+        {
+            if (id != null)
+            {
+                try
+                {
+                    CompetencyBeingLocated = await _jobCompetencyService.GetJobCompetencyById(id);
+                }
+                catch
+                {
+                    CompetencyBeingLocated = null;
+                }
+
+                if (CompetencyBeingLocated != null)
+                {
+                    if (CompetencyBeingLocated.Active == 1)
+                    {
+                        LocatingACompetency = true;
+                    }
+                }
+            }
+
+            if (!LocatingACompetency)
+            {
+                await PrepareNonLocatePage(typeId);
+            }
+            else
+            {
+                DisplayTopOfPage = true;
+                var sessionStr = HttpContext.Session.GetString("displayTopOfPage");
+                if (!string.IsNullOrEmpty(sessionStr))
+                {
+                    if (sessionStr.ToLower() == "false")
+                    {
+                        DisplayTopOfPage = false;
+                    }
+                }
+                sessionStr = HttpContext.Session.GetString("lastTableContainerHeight");
+                if (!string.IsNullOrEmpty(sessionStr))
+                {
+                    if (double.TryParse(sessionStr, out double num))
+                    {
+                        if (num > 300)
+                        {
+                            LastTableContainerHeight = num;
+                        }
+                    }
+                }
+
+                Type = await _jobCompetencyService.GetJobCompetencyTypeById(CompetencyBeingLocated.TypeId);
+                Competencies = await _jobCompetencyService.GetJobCompetenciesByTypeId(Type.Id);
+
+                RatingLevels = await _context.CompetencyRatingLevels.ToListAsync();
+
+                var activePositions = (await _jobPositionService.GetAllJobPositions()).Where(x => x.Active == 1).ToList();
+                int idToFind = id.Value;
+
+                PositionsThatHaveTheCompetency = new Dictionary<JobPositionDto, JobCompetencyRatingDto>();
+
+                foreach (var pos in activePositions)
+                {
+                    var jobCompetenciesOfType = await _jobCompetencyService.GetJobCompetencyRatingsByTypeId(pos.JobTitleId, Type.Id);
+
+                    foreach (var comp in jobCompetenciesOfType)
+                    {
+                        if (comp.CompetencyId == idToFind)
+                        {
+                            PositionsThatHaveTheCompetency.Add(pos, comp);
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return Page();
+        }
+
+        public async Task OnPostAsync(int typeId)
+        {
+            await PrepareNonLocatePage(typeId);
+        }
+
+    }
+}

--- a/Admin/Pages/Shared/_Position.cshtml
+++ b/Admin/Pages/Shared/_Position.cshtml
@@ -71,7 +71,7 @@
     <tbody>
         <tr>
             <td>
-                <div class="form-group">
+                <div class="form-group no-margin-bottom">
                     @{
                         bool onLand = true;
                         if (Model.JobHLCategory == "1")

--- a/Admin/Pages/Similar/Locate.cshtml
+++ b/Admin/Pages/Similar/Locate.cshtml
@@ -145,7 +145,7 @@
                                 @Html.DisplayFor(modelItem => item.JobTitleFre)
                             </td>
                              <td class="text-center">
-                                <a href="/Similar/Locate?id=@item.JobTitleId">Locate</a>
+                                <a href="/Similar/Locate?id=@item.JobTitleId" class="load-link">Locate</a>
                             </td>
                         </tr>
                     }

--- a/Admin/wwwroot/css/site.css
+++ b/Admin/wwwroot/css/site.css
@@ -803,6 +803,11 @@ header {
     max-height: 500px !important;
 }
 
+.besides-external-link {
+    display: inline-block;
+    margin-left: 6px;
+}
+
 @media print {
 
     .glyphicon {


### PR DESCRIPTION
Full list of changes:

 - Expanded the locate feature which existed for similar positions to work with certificates, certificate descriptions, and competencies. The idea is the same: be able to quickly see where elements have been added to positions. For each element type, the flow is the same: on their index page, there is a link which leads to the "Locate" page. The locate page is the same as the index, but each element has a locate link besides them (and there is no button to create elements). Once the user clicks the element they wish to locate, they will be brought to the same index page, except now with a table displaying the results. The results are displayed slightly differently based on the type of element located. However, for all three, the results table's first three columns remain consistent: they show the level, title in English and in French. The fourth column is unique. For certificates, it displays the certificate's selected description (if applicable). For certificate descriptions, it displays all certificates in that position that have the located certificate description. And for competencies, it displays the level of the competency (1 to 5). Each result screen can be printed. Navigation links are also included for everything users might need. Last PR also included links to locate elements directly from detail pages, and now, those links work. Also, on the results page of located items, every position listed has two links, one for details and one for edit. When those links are clicked, the page will scroll directly to the element that was located, and it will be highlighted (part of this code was featured in the previous PR)

**Small fixes:**

 - Fixed a wording error in an error message for creating/editing a certificate description with a name that already existed, but the element was deleted

 - Removed an unnecessary margin in the position create/edit page